### PR TITLE
Nullify some pointers, add more OpenMP locking, fix alignment requirements, cosmetic changes.

### DIFF
--- a/driver/spral_ssids.f90
+++ b/driver/spral_ssids.f90
@@ -1,6 +1,6 @@
 program run_prob
    use, intrinsic :: iso_c_binding
-   use omp_lib
+!$ use omp_lib
    use cuda_helper
    use spral_hw_topology
    use spral_rutherford_boeing

--- a/examples/C/ssids.c
+++ b/examples/C/ssids.c
@@ -62,4 +62,6 @@ int main(void) {
 
    int cuda_error = spral_ssids_free(&akeep, &fkeep);
    if(cuda_error!=0) exit(1);
+   
+   return 0;
 }

--- a/examples/C/ssids.c
+++ b/examples/C/ssids.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-void main(void) {
+int main(void) {
    /* Derived types */
    void *akeep, *fkeep;
    struct spral_ssids_options options;

--- a/src/hw_topology/hwloc_wrapper.hxx
+++ b/src/hw_topology/hwloc_wrapper.hxx
@@ -51,7 +51,7 @@ public:
    /** \brief Return vector of Numa nodes or just machine object */
    std::vector<hwloc_obj_t> get_numa_nodes() const {
       std::vector<hwloc_obj_t> regions;
-      int nregions = hwloc_get_nbobjs_by_type(topology_, HWLOC_OBJ_NODE);
+      int nregions = hwloc_get_nbobjs_by_type(topology_, HWLOC_OBJ_NUMANODE);
       if(nregions==0) {
          // No regions, just give machine
          regions.push_back(
@@ -63,7 +63,7 @@ public:
          regions.reserve(nregions);
          for(int i=0; i<nregions; ++i)
             regions.push_back(
-                  hwloc_get_obj_by_type(topology_, HWLOC_OBJ_NODE, i)
+                  hwloc_get_obj_by_type(topology_, HWLOC_OBJ_NUMANODE, i)
                   );
          return regions;
       }

--- a/src/ssids/akeep.f90
+++ b/src/ssids/akeep.f90
@@ -16,7 +16,7 @@ module spral_ssids_akeep
 
    type symbolic_subtree_ptr
       integer :: exec_loc
-      class(symbolic_subtree_base), pointer :: ptr
+      class(symbolic_subtree_base), pointer :: ptr => null()
    end type symbolic_subtree_ptr
 
    !

--- a/src/ssids/anal.f90
+++ b/src/ssids/anal.f90
@@ -4,7 +4,7 @@
 !> \note      Originally based on HSL_MA97 v2.2.0
 module spral_ssids_anal
    use, intrinsic :: iso_c_binding
-   use :: omp_lib
+!$ use :: omp_lib
    use spral_core_analyse, only : basic_analyse
    use spral_cuda, only : detect_gpu
    use spral_hw_topology, only : guess_topology, numa_region

--- a/src/ssids/contrib.f90
+++ b/src/ssids/contrib.f90
@@ -55,8 +55,8 @@ subroutine spral_ssids_contrib_get_data(ccontrib, n, val, ldval, rlist, &
    call c_f_pointer(ccontrib, fcontrib)
 
    do while(.not.fcontrib%ready)
-      ! FIXME: make below a taskyield?
-!$omp flush
+      ! FIXME: make below a taskyield? (was: flush)
+      !$omp taskyield
    end do
 
    n = fcontrib%n

--- a/src/ssids/cpu/AppendAlloc.hxx
+++ b/src/ssids/cpu/AppendAlloc.hxx
@@ -21,7 +21,13 @@ namespace append_alloc_internal {
  * Deallocation is not supported.
  */
 class Page {
-   static const int align = 32; // 32 byte alignment
+#if defined(__AVX512F__)
+  static const int align = 64; // 64 byte alignment
+#elif defined(__AVX__)
+  static const int align = 32; // 32 byte alignment
+#else
+  static const int align = 16; // 16 byte alignment
+#endif
 public:
    Page(size_t sz, Page* next=nullptr)
    : next(next), mem_(calloc(sz+align, 1)), ptr_(mem_), space_(sz+align)

--- a/src/ssids/cpu/BlockPool.hxx
+++ b/src/ssids/cpu/BlockPool.hxx
@@ -20,7 +20,13 @@ namespace spral { namespace ssids { namespace cpu {
 template <typename T, typename Allocator>
 class BlockPool {
    typedef typename std::allocator_traits<Allocator>::template rebind_traits<char> CharAllocTraits;
-   static const std::size_t align_ = 32; //< Alignement for AVX is 32 bytes
+#if defined(__AVX512F__)
+  static const std::size_t align_ = 64; //< Alignment for AVX512 is 64 bytes
+#elif defined(__AVX__)
+  static const std::size_t align_ = 32; //< Alignment for AVX(2) is 32 bytes
+#else
+  static const std::size_t align_ = 16; //< Alignment for SSE(2,3,4.1,4.2) or Power's VSX is 16 bytes
+#endif
 public:
    /* Not copyable */
    BlockPool(BlockPool const&) =delete;

--- a/src/ssids/cpu/BuddyAllocator.hxx
+++ b/src/ssids/cpu/BuddyAllocator.hxx
@@ -38,9 +38,15 @@ class Page {
    // \{
    typedef typename std::allocator_traits<CharAllocator>::template rebind_traits<int> IntAllocTraits;
    // \}
-   static int const nlevel=16; ///< Number of divisions to smallest allocation
-                               ///  unit.
-   static int const align=32; ///< Underlying alignment of all pointers returned
+   static int const nlevel=16; ///< Number of divisions to smallest allocation unit.
+  
+#if defined(__AVX512F__)
+  static int const align=64; ///< Underlying alignment of all pointers returned
+#elif defined(__AVX__)
+  static int const align=32; ///< Underlying alignment of all pointers returned
+#else
+  static int const align=16; ///< Underlying alignment of all pointers returned
+#endif
    static int const ISSUED_FLAG = -2; ///< Flag: value is issued
 public:
    // \{

--- a/src/ssids/cpu/SimpleAlignedAlloc.hxx
+++ b/src/ssids/cpu/SimpleAlignedAlloc.hxx
@@ -18,7 +18,13 @@ namespace spral { namespace ssids { namespace cpu {
  */
 template <typename T>
 class SimpleAlignedAllocator {
-   int const align = 32;
+#if defined(__AVX512F__)
+  int const align = 64;
+#elif defined(__AVX__)
+  int const align = 32;
+#else
+  int const align = 16;
+#endif
 public:
    typedef T value_type;
 

--- a/src/ssids/cpu/Workspace.hxx
+++ b/src/ssids/cpu/Workspace.hxx
@@ -15,7 +15,13 @@ namespace spral { namespace ssids { namespace cpu {
  * function provides a pointer to it after ensuring it is of at least the
  * given size. */
 class Workspace {
-   static int const align = 32;
+#if defined(__AVX512F__)
+  static int const align = 64;
+#elif defined(__AVX__)
+  static int const align = 32;
+#else
+  static int const align = 16;
+#endif
 public:
    Workspace(size_t sz)
    {

--- a/src/ssids/cpu/cpu_iface.hxx
+++ b/src/ssids/cpu/cpu_iface.hxx
@@ -35,7 +35,13 @@ struct cpu_factor_options {
 /** Return nearest value greater than supplied lda that is multiple of alignment */
 template<typename T>
 size_t align_lda(size_t lda) {
-   int const align = 32;
+#if defined(__AVX512F__)
+  int const align = 64;
+#elif defined(__AVX__)
+  int const align = 32;
+#else
+  int const align = 16;
+#endif
    static_assert(align % sizeof(T) == 0, "Can only align if T divides align");
    int const Talign = align / sizeof(T);
    return Talign*((lda-1)/Talign + 1);

--- a/src/ssids/cpu/kernels/SimdVec.hxx
+++ b/src/ssids/cpu/kernels/SimdVec.hxx
@@ -167,7 +167,15 @@ public:
    /// Extract indvidual elements of vector (messy and inefficient)
    /// idx MUST be < vector_length.
    double operator[](size_t idx) const {
-      double __attribute__((aligned(32))) val_as_array[vector_length];
+      double
+#if defined(__AVX512F__)
+        __attribute__((aligned(64)))
+#elif defined(__AVX__)
+        __attribute__((aligned(32)))
+#else
+        __attribute__((aligned(16)))
+#endif
+        val_as_array[vector_length];
       store_aligned(val_as_array);
       return val_as_array[idx];
    }

--- a/src/ssids/cpu/kernels/block_ldlt.hxx
+++ b/src/ssids/cpu/kernels/block_ldlt.hxx
@@ -179,8 +179,16 @@ void find_maxloc(const int from, const T *a, int lda, T &bestv_out, int &rloc, i
    bestr = blend(bestr, bestr2, v_gt_bestv);
    bestc = blend(bestc, bestc2, v_gt_bestv);
    // Extract results
+#if defined(__AVX512F__)
+   T __attribute__((aligned(64))) bv2[SimdVecT::vector_length];
+   intT __attribute__((aligned(64))) br2[SimdVecT::vector_length], bc2[SimdVecT::vector_length];
+#elif defined(__AVX__)
    T __attribute__((aligned(32))) bv2[SimdVecT::vector_length];
    intT __attribute__((aligned(32))) br2[SimdVecT::vector_length], bc2[SimdVecT::vector_length];
+#else
+   T __attribute__((aligned(16))) bv2[SimdVecT::vector_length];
+   intT __attribute__((aligned(16))) br2[SimdVecT::vector_length], bc2[SimdVecT::vector_length];
+#endif
    bestv.store_aligned(bv2);
    bestr.store_aligned(&br2[0].d);
    bestc.store_aligned(&bc2[0].d);

--- a/src/ssids/cpu/kernels/calc_ld.hxx
+++ b/src/ssids/cpu/kernels/calc_ld.hxx
@@ -20,7 +20,13 @@ namespace spral { namespace ssids { namespace cpu {
  */
 template <typename T>
 int offset_to_align(T* ptr) {
-   int const align = 32;
+#if defined(__AVX512F__)
+  int const align = 64;
+#elif defined(__AVX__)
+  int const align = 32;
+#else
+  int const align = 16;
+#endif
    uintptr_t offset = align - (reinterpret_cast<uintptr_t>(ptr) % align);
    offset /= sizeof(T);
    if((reinterpret_cast<uintptr_t>(ptr+offset) % align) == 0) return offset;

--- a/src/ssids/cpu/kernels/ldlt_app.cxx
+++ b/src/ssids/cpu/kernels/ldlt_app.cxx
@@ -240,7 +240,13 @@ private:
 
 /** Returns true if ptr is suitably aligned for AVX, false if not */
 bool is_aligned(void* ptr) {
-   const int align = 32;
+#if defined(__AVX512F__)
+  const int align = 64;
+#elif defined(__AVX__)
+  const int align = 32;
+#else
+  const int align = 16;
+#endif
    return (reinterpret_cast<uintptr_t>(ptr) % align == 0);
 }
 
@@ -2423,7 +2429,13 @@ using namespace spral::ssids::cpu::ldlt_app_internal;
 
 template<typename T>
 size_t ldlt_app_factor_mem_required(int m, int n, int block_size) {
-   int const align = 32;
+#if defined(__AVX512F__)
+  int const align = 64;
+#elif defined(__AVX__)
+  int const align = 32;
+#else
+  int const align = 16;
+#endif
    return align_lda<T>(m) * n * sizeof(T) + align; // CopyBackup
 }
 

--- a/src/ssids/fkeep.f90
+++ b/src/ssids/fkeep.f90
@@ -6,7 +6,7 @@
 !> \brief Define ssids_fkeep type and associated procedures (CPU version)
 module spral_ssids_fkeep
    use, intrinsic :: iso_c_binding
-   use :: omp_lib
+!$ use :: omp_lib
    use spral_ssids_akeep, only : ssids_akeep
    use spral_ssids_contrib, only : contrib_type
    use spral_ssids_datatypes
@@ -22,7 +22,7 @@ module spral_ssids_fkeep
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    type numeric_subtree_ptr
-      class(numeric_subtree_base), pointer :: ptr
+      class(numeric_subtree_base), pointer :: ptr => null()
    end type numeric_subtree_ptr
 
    !

--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -1218,7 +1218,7 @@ subroutine factor_indef( stream, lev, lvlptr, nnodes, nodes, lvllist, sparent, &
    integer :: ind_len, B_len
    integer :: i, j, k, p
    integer :: ncb, last_ln, llist, maxr
-   integer :: ndelay, blkm, blkn, nelim, parent, node
+   integer :: ndelay, blkm, blkn, nelim, parent, node, dif
    integer, dimension(:), pointer :: lperm
 
    type(C_PTR) :: ptr_D, ptr_L, ptr_LD
@@ -1417,8 +1417,10 @@ subroutine factor_indef( stream, lev, lvlptr, nnodes, nodes, lvllist, sparent, &
          ! Record delays
          nodes(node)%nelim = nelim
          if(blkn.lt.blkm) then
-!$OMP ATOMIC
-            nodes(parent)%ndelay = nodes(parent)%ndelay + (blkn - nelim)
+            dif = blkn - nelim
+!$OMP ATOMIC UPDATE
+            nodes(parent)%ndelay = nodes(parent)%ndelay + dif
+!$OMP END ATOMIC
          endif
          stats%num_delay = stats%num_delay + blkn - nelim
          do j = blkm, blkm-nelim+1, -1

--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -1373,6 +1373,10 @@ subroutine push_omp_settings(user_settings, flag)
    type(omp_settings), intent(out) :: user_settings
    integer, intent(inout) :: flag
 
+   ! dummy operations if no OpenMP
+   user_settings%nested = .true.
+   user_settings%max_active_levels = 2
+
 ! !$ ! issue an error if we don't have cancellation (could lead to segfaults)
 ! !$ if(.not.omp_get_cancellation()) then
 ! !$    flag = SSIDS_ERROR_OMP_CANCELLATION

--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -1076,8 +1076,11 @@ subroutine ssids_solve_one_double(x1, akeep, fkeep, options, inform, job)
    integer :: ldx
 
    ldx = size(x1)
-   call ssids_solve_mult_double(1, x1, ldx, akeep, fkeep, options, inform, &
-      job=job)
+   if (present(job)) then
+      call ssids_solve_mult_double(1, x1, ldx, akeep, fkeep, options, inform, job)
+   else
+      call ssids_solve_mult_double(1, x1, ldx, akeep, fkeep, options, inform)
+   end if
 end subroutine ssids_solve_one_double
 
 !*************************************************************************

--- a/tests/ssids/kernels/AlignedAllocator.hxx
+++ b/tests/ssids/kernels/AlignedAllocator.hxx
@@ -14,7 +14,14 @@ namespace spral { namespace test {
 template <class T>
 class AlignedAllocator {
 public:
-   const int alignment = 32; // Number of bytes boundary we align to
+  // Number of bytes boundary we align to
+#if defined(__AVX512F__)
+  const int alignment = 64;
+#elif defined(__AVX__)
+  const int alignment = 32;
+#else
+  const int alignment = 16;
+#endif
 
    typedef T value_type;
 

--- a/tests/ssids/kernels/block_ldlt.cxx
+++ b/tests/ssids/kernels/block_ldlt.cxx
@@ -177,7 +177,14 @@ void find_maxloc_simple(const int from, const T *a, int lda, T &bestv, int &rloc
 template<typename T, int BLOCK_SIZE, bool debug=false>
 int test_maxloc(int from, bool zero=false) {
    int const lda = 2*BLOCK_SIZE;
-   alignas(32) T a[BLOCK_SIZE*lda];
+#if defined(__AVX512F__)
+   alignas(64)
+#elif defined(__AVX__)
+   alignas(32)
+#else
+   alignas(16)
+#endif
+     T a[BLOCK_SIZE*lda];
 
    /* Setup a random matrix. Entries in lwr triangle < 1.0, others = 100.0 */
    for(int j=0; j<from; j++)


### PR DESCRIPTION
- In `src/ssids/cpu/kernels/ldlt_app.cxx`, `Column<T>` class, replaced various mutual exclusion strategies with OpenMP locks.
Made `npass_` component uniformly protected by OpenMP locks, instead of
the previous combination of locks, atomics, and no protection at all.

- Change various alignment requirements from a fixed number of 32 bytes, to either 64 for AVX512, 32 for the AVX and newer CPUs, and 16 for the rest, including non-Intel ones.
Not a perfect solution, but it reflects the present hardware situation.

- Other changes merely cosmetic.