### PR TITLE
A fix in the case of no GPU on the build machine.

### DIFF
--- a/no_gpu_on_build/m4/spral_prog_nvcc.m4
+++ b/no_gpu_on_build/m4/spral_prog_nvcc.m4
@@ -1,0 +1,25 @@
+#
+# SYNOPSIS
+#
+#     SPRAL_PROG_NVCC([compiler-search-list])
+#
+# DESCRIPTION
+#
+#  This macro looks for the CUDA C compiler to use. On success, the following
+#  variables are defined:
+#     $NVCC          The CUDA compiler command
+#     $NVCCFLAGS     The flags pased to the CUDA compiler
+#     $NVCC_ARCH_SM  The CUDA architectures to compile for
+#
+
+AC_DEFUN([SPRAL_PROG_NVCC], [
+
+AC_ARG_VAR(NVCC,[CUDA compiler command])
+AC_ARG_VAR(NVCCFLAGS,[CUDA compiler flags])
+
+test "x$NVCC" = x && AC_CHECK_PROGS(NVCC,nvcc)
+$NVCC -DNDEBUG nvcc_arch_sm.c -o nvcc_arch_sm -lcuda
+test "x$NVCC_ARCH_SM" = x && NVCC_ARCH_SM="-arch=sm_37"
+test "x$NVCCFLAGS" = x && NVCCFLAGS="-std=c++11 -g $NVCC_ARCH_SM"
+
+])dnl SPRAL_PROG_NVCC


### PR DESCRIPTION
This file should be substituted for `m4/spral_prog_nvcc.m4` in the case that there is no GPU on the build machine, so `nvcc_arch_sm` tool cannot be run.

Unfortunately, that leaves a person installing the package to manually enter the desired SM architecture, if the one provided here (3.7, for K80s) is not suitable.

The alternative would be to build for ALL possible architectures, which is totally redundant in most cases.