### PR TITLE
Fix handling of indices in C interface for SSIDS

### DIFF
--- a/examples/C/ssids.c
+++ b/examples/C/ssids.c
@@ -12,6 +12,7 @@ int main(void) {
    /* Initialize derived types */
    akeep = NULL; fkeep = NULL; /* Important that these are NULL to start with */
    spral_ssids_default_options(&options);
+   options.array_base = 1; /* Need to set to 1 if using Fortran 1-based indexing */
 
    /* Data for matrix:
     * ( 2  1         )

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -148,6 +148,7 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   logical :: fcheck
   integer(C_INT), dimension(:), pointer :: forder
+  integer(C_INT), dimension(:), allocatable, target :: forder_alloc
   real(C_DOUBLE), dimension(:), pointer :: fval
   type(ssids_akeep), pointer :: fakeep
   type(ssids_options) :: foptions
@@ -165,6 +166,11 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   else
      nullify(forder)
   end if
+  if (ASSOCIATED(forder) .and. cindexed) then
+     allocate(forder_alloc(n))
+     forder_alloc(:) = forder(:) + 1
+     forder => forder_alloc
+  endif
   if (C_ASSOCIATED(cptr)) then
      call C_F_POINTER(cptr, fptr, shape=(/ n+1 /))
   else
@@ -218,7 +224,10 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   end if
 
   ! Copy arguments out
-  if (ASSOCIATED(forder) .and. cindexed) forder(:) = forder(:) - 1
+  if (ASSOCIATED(forder) .and. cindexed) then
+     call C_F_POINTER(corder, forder, shape = (/ n /) )
+     forder(:) = forder_alloc(:) - 1
+  endif
   call copy_inform_out(finform, cinform)
 end subroutine spral_ssids_analyse
 
@@ -243,6 +252,7 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   logical :: fcheck
   integer(C_INT), dimension(:), pointer :: forder
+  integer(C_INT), dimension(:), allocatable, target :: forder_alloc
   real(C_DOUBLE), dimension(:), pointer :: fval
   type(ssids_akeep), pointer :: fakeep
   type(ssids_options) :: foptions
@@ -260,6 +270,11 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   else
      nullify(forder)
   end if
+  if (ASSOCIATED(forder) .and. cindexed) then
+     allocate(forder_alloc(n))
+     forder_alloc(:) = forder(:) + 1
+     forder => forder_alloc
+  endif
   if (C_ASSOCIATED(cptr)) then
      call C_F_POINTER(cptr, fptr, shape=(/ n+1 /))
   else
@@ -313,7 +328,10 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   end if
 
   ! Copy arguments out
-  if (ASSOCIATED(forder) .and. cindexed) forder(:) = forder(:) - 1
+  if (ASSOCIATED(forder) .and. cindexed) then
+     call C_F_POINTER(corder, forder, shape = (/ n /) )
+     forder(:) = forder_alloc(:) - 1
+  endif
   call copy_inform_out(finform, cinform)
 end subroutine spral_ssids_analyse_ptr32
 
@@ -337,6 +355,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   integer(C_INT), dimension(:), pointer :: fcol
   integer(C_INT), dimension(:), allocatable, target :: fcol_alloc
   integer(C_INT), dimension(:), pointer :: forder
+  integer(C_INT), dimension(:), allocatable, target :: forder_alloc
   real(C_DOUBLE), dimension(:), pointer :: fval
   type(ssids_akeep), pointer :: fakeep
   type(ssids_options) :: foptions
@@ -353,6 +372,11 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   else
      nullify(forder)
   end if
+  if (ASSOCIATED(forder) .and. cindexed) then
+     allocate(forder_alloc(n))
+     forder_alloc(:) = forder(:) + 1
+     forder => forder_alloc
+  endif
   if (C_ASSOCIATED(crow)) then
      call C_F_POINTER(crow, frow, shape=(/ ne /))
   else
@@ -406,7 +430,10 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   end if
 
   ! Copy arguments out
-  if (ASSOCIATED(forder) .and. cindexed) forder(:) = forder(:) - 1
+  if (ASSOCIATED(forder) .and. cindexed) then
+     call C_F_POINTER(corder, forder, shape = (/ n /) )
+     forder(:) = forder_alloc(:) - 1
+  endif
   call copy_inform_out(finform, cinform)
 end subroutine spral_ssids_analyse_coord
 

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -170,7 +170,7 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   else
      nullify(fptr)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(fptr_alloc(n+1))
      fptr_alloc(:) = fptr(:) + 1
      fptr => fptr_alloc
@@ -180,7 +180,7 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   else
      nullify(frow)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(frow_alloc(n+1))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
@@ -265,7 +265,7 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   else
      nullify(fptr)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(fptr_alloc(n+1))
      fptr_alloc(:) = fptr(:) + 1
      fptr => fptr_alloc
@@ -275,7 +275,7 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   else
      nullify(frow)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(frow_alloc(n+1))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
@@ -358,7 +358,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   else
      nullify(frow)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(frow_alloc(n+1))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
@@ -368,7 +368,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   else
      nullify(fcol)
   end if
-  if (.not. cindexed) then
+  if (cindexed) then
      allocate(fcol_alloc(n+1))
      fcol_alloc(:) = fcol(:) + 1
      fcol => fcol_alloc
@@ -446,13 +446,13 @@ subroutine spral_ssids_factor(cposdef, cptr, crow, val, cscale, cakeep, cfkeep,&
   call C_F_POINTER(cakeep, fakeep) ! Pulled forward so we can use it
   if (C_ASSOCIATED(cptr) .and. C_ASSOCIATED(crow)) then
      call C_F_POINTER(cptr, fptr, shape=(/ fakeep%n+1 /))
-     if (.not. cindexed) then
+     if (cindexed) then
         allocate(fptr_alloc(fakeep%n+1))
         fptr_alloc(:) = fptr(:) + 1
         fptr => fptr_alloc
      end if
      call C_F_POINTER(crow, frow, shape=(/ fptr(fakeep%n+1)-1 /))
-     if (.not. cindexed) then
+     if (cindexed) then
         allocate(frow_alloc(fakeep%n+1))
         frow_alloc(:) = frow(:) + 1
         frow => frow_alloc
@@ -533,13 +533,13 @@ subroutine spral_ssids_factor_ptr32(cposdef, cptr, crow, val, cscale, cakeep, &
   call C_F_POINTER(cakeep, fakeep) ! Pulled forward so we can use it
   if (C_ASSOCIATED(cptr) .and. C_ASSOCIATED(crow)) then
      call C_F_POINTER(cptr, fptr, shape=(/ fakeep%n+1 /))
-     if (.not. cindexed) then
+     if (cindexed) then
         allocate(fptr_alloc(fakeep%n+1))
         fptr_alloc(:) = fptr(:) + 1
         fptr => fptr_alloc
      end if
      call C_F_POINTER(crow, frow, shape=(/ fptr(fakeep%n+1)-1 /))
-     if (.not. cindexed) then
+     if (cindexed) then
         allocate(frow_alloc(fakeep%n+1))
         frow_alloc(:) = frow(:) + 1
         frow => frow_alloc

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -181,7 +181,7 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
      nullify(frow)
   end if
   if (cindexed) then
-     allocate(frow_alloc(n+1))
+     allocate(frow_alloc(fptr(n+1)-1))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
   end if
@@ -276,7 +276,7 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
      nullify(frow)
   end if
   if (cindexed) then
-     allocate(frow_alloc(n+1))
+     allocate(frow_alloc(fptr(n+1)-1))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
   end if
@@ -359,7 +359,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
      nullify(frow)
   end if
   if (cindexed) then
-     allocate(frow_alloc(n+1))
+     allocate(frow_alloc(ne))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
   end if
@@ -369,7 +369,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
      nullify(fcol)
   end if
   if (cindexed) then
-     allocate(fcol_alloc(n+1))
+     allocate(fcol_alloc(ne))
      fcol_alloc(:) = fcol(:) + 1
      fcol => fcol_alloc
   end if


### PR DESCRIPTION
C vs Fortran indexing was flipped in the C interface for SSIDS: If the user set `spral_ssids_options::array_base` to `0` to use C indexing, SSIDS would assume the input is using Fortran indexing. If the user set `spral_ssids_options::array_base` to `1` to use Fortran indexing, SSIDS would assume the input is using C indexing. Looks like this was a copy paste error from the C interface of MA97, where indexing is checked with `.not. f_arrays`. Instead of `f_arrays` we have `cindexed` here, so `.not. f_arrays` should have become `cindexed`. But as the `.not.` was not removed the logic became flawed.

The C example was lucky to be working, as it uses 1-based indexing, but did not set `spral_ssids_options::array_base` to `1` as it should. That 2nd error cancelled out the first one and made the example work.

Additionally, the size for allocating some of the temporary vectors for converted C indices was wrong. Also a user-provided ordering was not properly converted to Fortran indexing.