### PR TITLE
Fix solve call and comment out GPU print statement

### DIFF
--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -679,7 +679,11 @@ subroutine spral_ssids_solve(job, nrhs, cx, ldx, cakeep, cfkeep, coptions, &
   end if
 
   ! Call Fortran routine
-  call ssids_solve(nrhs, fx, ldx, fakeep, ffkeep, foptions, finform, job=job)
+  if (job .eq. 0) then
+     call ssids_solve(nrhs, fx, ldx, fakeep, ffkeep, foptions, finform)
+  else
+     call ssids_solve(nrhs, fx, ldx, fakeep, ffkeep, foptions, finform, job=job)
+  end if
 
   ! Copy arguments out
   call copy_inform_out(finform, cinform)

--- a/src/hw_topology/hwloc_wrapper.hxx
+++ b/src/hw_topology/hwloc_wrapper.hxx
@@ -81,7 +81,7 @@ public:
       int ngpu;
       cudaError_t cuda_error = cudaGetDeviceCount(&ngpu);
       if(cuda_error != cudaSuccess) {
-         printf("Error using CUDA. Assuming no GPUs.\n");
+         //printf("Error using CUDA. Assuming no GPUs.\n");
          return gpus; // empty
       }
       /* Now for each device search up its topology tree and see if we


### PR DESCRIPTION
This addresses a bug when using `ssids_solve` in the C interface and comments out a `printf` statement that seems unnecessary, especially when calling multiple solve routines in sequence.