### PR TITLE
LANL-ANSI modifications

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -1,0 +1,98 @@
+## Dependencies
+### Software Directory
+First, create a directory where the dependencies will be compiled, e.g.,
+```bash
+mkdir -p ${HOME}/Software
+```
+The remainder of this guide assumes such a directory has been created.
+
+### METIS
+Next, compile the [COIN-OR version of METIS](https://github.com/coin-or-tools/ThirdParty-Metis), e.g.,
+```bash
+cd ${HOME}/Software
+git clone https://github.com/coin-or-tools/ThirdParty-Metis.git
+cd ThirdParty-Metis && ./get.Metis
+mkdir build
+cd build
+../configure --prefix=${PWD}
+make && make install
+export METISDIR=${PWD}
+```
+
+### hwloc
+Next, ensure the [hardware locality library](https://www.open-mpi.org/projects/hwloc/) is installed on your system.
+For example, on Ubuntu 20.04 LTS, this can be accomplished via
+```bash
+sudo apt-get install hwloc libhwloc-dev
+```
+
+### BLAS
+A number of BLAS libraries can be used for compilation, including the proprietary [Intel MKL](https://software.intel.com/en-us/mkl).
+One open-source option is [OpenBLAS](https://www.openblas.net), which can be installed on Ubuntu 20.04 LTS via
+```bash
+sudo apt install libopenblas-dev
+```
+This is the library used throughout the remainder of this guide.
+
+### CUDA (optional)
+If you're installing with [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) GPU support, ensure it is installed and that the following environment variables are set:
+```
+export CUDA_HOME="/usr/local/cuda" # Change this to your system-specific path.
+export PATH="${PATH}:${CUDA_HOME}/bin"
+export LIBRARY_PATH="${LIBRARY_PATH}:${CUDA_HOME}/lib64"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CUDA_HOME}/lib64"
+export C_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${CUDA_HOME}/include"
+export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${CUDA_HOME}/include"
+export NVCC_INCLUDE_FLAGS="${NVCC_INCLUDE_FLAGS}:-I${CUDA_HOME}/include"
+```
+
+## Compilation
+### Multicore CPUs Only
+To compile with only multicore CPU support, execute
+```bash
+cd ${HOME}/Software
+git clone https://github.com/lanl-ansi/spral.git
+cd spral
+./autogen.sh # If compiling from scratch.
+mkdir build
+cd build
+CFLAGS=-fPIC CPPFLAGS=-fPIC CXXFLAGS=-fPIC FFLAGS=-fPIC \
+   FCFLAGS=-fPIC ../configure --prefix=${PWD}/build \
+   --with-blas="-lopenblas" --with-lapack="-llapack" \
+   --with-metis="-L${METISDIR}/lib -lcoinmetis" \
+   --with-metis-inc-dir="${METISDIR}/include/coin-or/metis"
+make && make install
+```
+
+### Multicore CPUs and NVIDIA GPUs (optional)
+To compile with multicore CPU and NVIDIA GPU support, execute
+```bash
+cd ${HOME}/Software
+git clone https://github.com/lanl-ansi/spral.git
+cd spral
+./autogen.sh # If compiling from scratch.
+mkdir build
+cd build
+CFLAGS=-fPIC CPPFLAGS=-fPIC CXXFLAGS=-fPIC FFLAGS=-fPIC \
+   FCFLAGS=-fPIC NVCCFLAGS="-shared -Xcompiler -fPIC" \
+   ../configure --prefix=${PWD}/build \
+   --with-blas="-lopenblas" --with-lapack="-llapack" \
+   --with-metis="-L${METISDIR}/lib -lcoinmetis" \
+   --with-metis-inc-dir="${METISDIR}/include/coin-or/metis"
+make && make install
+```
+If your GPUs are not being recognized, consider uncommenting line 91 and commenting line 92 of `src/hw_topology/hwloc_wrapper.hxx`, then recompiling.
+The methods for recognizing GPUs do not seem to function independently of the type of system being used.
+
+## Usage
+For future use, set the SPRAL directory environment variable via
+```bash
+export SPRALDIR=${PWD}/build
+```
+from the `${HOME}/Software/spral` directory.
+Also, ensure the following environment variables are set when using the library:
+```bash
+export OMP_CANCELLATION=TRUE
+export OMP_NESTED=TRUE
+export OMP_PROC_BIND=TRUE
+```

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,11 +15,16 @@ AM_NVCC_FLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Xptxas="${PTX_FLAGS
 else
 AM_NVCC_FLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Xptxas="${PTX_FLAGS}"
 endif
+AM_NVCC_FLAGS += -gencode arch=compute_50,code=sm_50
+AM_NVCC_FLAGS += -gencode arch=compute_60,code=sm_60
+AM_NVCC_FLAGS += -gencode arch=compute_61,code=sm_61
+AM_NVCC_FLAGS += -gencode arch=compute_70,code=sm_70
+# AM_NVCC_FLAGS += -gencode arch=compute_75,code=sm_75
 AM_LD_FLAGS = -lcuda
 NVCCLINK = \
 	$(NVCC) $(NVCCFLAGS) $(AM_NVCC_FLAGS) $(AM_LD_FLAGS) $(LDFLAGS) $(OPENMP_LIB) -o $@
 .cu.o:
-	$(NVCC) $(NVCCFLAGS) $(AM_NVCC_FLAGS) -dc -o $@ $<
+	$(NVCC) $(NVCCFLAGS) $(AM_NVCC_FLAGS) -rdc false -c -o $@ $<
 
 # Include directory for standard C
 AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(OPENMP_CFLAGS) \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,17 @@ our proprietary licenced [HSL Library](http://www.hsl.rl.ac.uk/)
 We use a standard autotools-based build:
 ```bash
 ./autogen.sh # If compiling from fresh git checkout
-./configure
+mkdir build
+cd build
+../configure
 make
 make install
+```
+
+## Usage at a Glance
+When using SSIDS, ensure the following environment variables are set:
+```bash
+export OMP_CANCELLATION=TRUE
+export OMP_NESTED=TRUE
+export OMP_PROC_BIND=TRUE
 ```

--- a/driver/spral_ssids.F90
+++ b/driver/spral_ssids.F90
@@ -229,7 +229,7 @@ contains
     integer :: i
     character(len=200) :: argval
     logical :: seen_fname
-      
+
     ! Defaults
     nrhs = 1
     force_psdef = .false.

--- a/m4/ax_lapack.m4
+++ b/m4/ax_lapack.m4
@@ -81,7 +81,8 @@ case $with_lapack in
 esac
 
 # Get fortran linker name of LAPACK function to check for.
-AC_F77_FUNC(cheev)
+dnl AC_F77_FUNC(spotrf)
+AC_F77_FUNC(dpotrf)
 
 # We cannot use LAPACK if BLAS is not found
 if test "x$ax_blas_ok" != xyes; then
@@ -92,8 +93,8 @@ fi
 # First, check LAPACK_LIBS environment variable
 if test "x$LAPACK_LIBS" != x; then
         save_LIBS="$LIBS"; LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS $FLIBS"
-        AC_MSG_CHECKING([for $cheev in $LAPACK_LIBS])
-        AC_TRY_LINK_FUNC($cheev, [ax_lapack_ok=yes], [LAPACK_LIBS=""])
+        AC_MSG_CHECKING([for $dpotrf in $LAPACK_LIBS])
+        AC_TRY_LINK_FUNC($dpotrf, [ax_lapack_ok=yes], [LAPACK_LIBS=""])
         AC_MSG_RESULT($ax_lapack_ok)
         LIBS="$save_LIBS"
         if test $ax_lapack_ok = no; then
@@ -104,7 +105,7 @@ fi
 # LAPACK linked to by default?  (is sometimes included in BLAS lib)
 if test $ax_lapack_ok = no; then
         save_LIBS="$LIBS"; LIBS="$LIBS $BLAS_LIBS $FLIBS"
-        AC_CHECK_FUNC($cheev, [ax_lapack_ok=yes])
+        AC_CHECK_FUNC($dpotrf, [ax_lapack_ok=yes])
         LIBS="$save_LIBS"
 fi
 
@@ -112,7 +113,7 @@ fi
 for lapack in lapack lapack_rs6k; do
         if test $ax_lapack_ok = no; then
                 save_LIBS="$LIBS"; LIBS="$BLAS_LIBS $LIBS"
-                AC_CHECK_LIB($lapack, $cheev,
+                AC_CHECK_LIB($lapack, $dpotrf,
                     [ax_lapack_ok=yes; LAPACK_LIBS="-l$lapack"], [], [$FLIBS])
                 LIBS="$save_LIBS"
         fi

--- a/src/hw_topology/hwloc_wrapper.hxx
+++ b/src/hw_topology/hwloc_wrapper.hxx
@@ -87,7 +87,9 @@ public:
       /* Now for each device search up its topology tree and see if we
        * encounter obj. */
       for(int i=0; i<ngpu; ++i) {
-         hwloc_obj_t p = hwloc_cudart_get_device_osdev_by_index(topology_, i);
+         // TODO: Switch between the two calls below as appropriate.
+         // hwloc_obj_t p = hwloc_cudart_get_device_osdev_by_index(topology_, i);
+         hwloc_obj_t p = hwloc_cudart_get_device_pcidev(topology_, i);
          for(; p; p=p->parent) {
             if(p==obj) {
                gpus.push_back(i);


### PR DESCRIPTION
The file `src/ssids/anal.f90` was also modified but it's quite difficult to see the difference (https://github.com/lanl-ansi/spral/blob/master/src/ssids/anal.f90).

I used the fork of `lanl-ansi` to compile SPRAL with Yggdrasil (https://github.com/JuliaPackaging/Yggdrasil/pull/2924)