### PR TITLE
Remove -lrt flag for Windows platforms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,12 +36,12 @@ AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
 # FIXME: make below configurable
 if HAVE_NVCC
 LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		  -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
+		  -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
 SPRAL_LINK_LIBS = -lcublas
 SPRALLINK = $(NVCCLINK)
 else
 LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		  $(HWLOC_LIBS) $(FCLIBS) -lrt
+		  $(HWLOC_LIBS) $(FCLIBS)
 SPRAL_LINK_LIBS = $(CXXLIB)
 SPRALLINK = $(FCLINK)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,25 +35,21 @@ AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
 
 # FIXME: make below configurable
 if HAVE_NVCC
-	if BUILD_WINDOWS
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		-L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
-	else
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		-L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
-	endif
-	SPRAL_LINK_LIBS = -lcublas
-	SPRALLINK = $(NVCCLINK)
+if BUILD_WINDOWS
+LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
 else
-	if BUILD_WINDOWS
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		$(HWLOC_LIBS) $(FCLIBS)
-	else
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		$(HWLOC_LIBS) $(FCLIBS) -lrt
-	endif
-	SPRAL_LINK_LIBS = $(CXXLIB)
-	SPRALLINK = $(FCLINK)
+LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
+endif
+SPRAL_LINK_LIBS = -lcublas
+SPRALLINK = $(NVCCLINK)
+else
+if BUILD_WINDOWS
+LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS)
+else
+LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS) -lrt
+endif
+SPRAL_LINK_LIBS = $(CXXLIB)
+SPRALLINK = $(FCLINK)
 endif
 
 lib_LIBRARIES = libspral.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,15 +35,21 @@ AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
 
 # FIXME: make below configurable
 if HAVE_NVCC
-LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		  -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
-SPRAL_LINK_LIBS = -lcublas
-SPRALLINK = $(NVCCLINK)
+	if BUILD_WINDOWS
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
+	else
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
+	endif
+	SPRAL_LINK_LIBS = -lcublas
+	SPRALLINK = $(NVCCLINK)
 else
-LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
-		  $(HWLOC_LIBS) $(FCLIBS)
-SPRAL_LINK_LIBS = $(CXXLIB)
-SPRALLINK = $(FCLINK)
+	if BUILD_WINDOWS
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS)
+	else
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS) -lrt
+	endif
+	SPRAL_LINK_LIBS = $(CXXLIB)
+	SPRALLINK = $(FCLINK)
 endif
 
 lib_LIBRARIES = libspral.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,17 +36,21 @@ AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
 # FIXME: make below configurable
 if HAVE_NVCC
 	if BUILD_WINDOWS
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
+		-L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
 	else
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
+		-L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
 	endif
 	SPRAL_LINK_LIBS = -lcublas
 	SPRALLINK = $(NVCCLINK)
 else
 	if BUILD_WINDOWS
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS)
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
+		$(HWLOC_LIBS) $(FCLIBS)
 	else
-		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS) -lrt
+		LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) \
+		$(HWLOC_LIBS) $(FCLIBS) -lrt
 	endif
 	SPRAL_LINK_LIBS = $(CXXLIB)
 	SPRALLINK = $(FCLINK)

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,19 @@ AC_CONFIG_SRCDIR([src/ssids/ssids.f90])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE
 
+# AC_CANONICAL_HOST is needed to access the 'host_os' variable
+AC_CANONICAL_HOST
+
+build_windows=no
+case "${host_os}" in
+	cygwin*|mingw*)
+		build_windows=yes
+		;;
+esac
+
+# Pass the conditional to automake
+AM_CONDITIONAL([BUILD_WINDOWS], [test "$build_windows" = "yes"])
+
 # Allow disabling of OpenMP
 AC_ARG_ENABLE([openmp],
    AS_HELP_STRING([--disable-openmp], [Disable OpenMP parallelism. Not recommended.])


### PR DESCRIPTION
The flag `-lrt` is not available with `MinGW` on Windows.