### PR TITLE
Use C_LONG instead of C_LONG_LONG for 32 bits platforms

### DIFF
--- a/interfaces/C/matrix_util.f90
+++ b/interfaces/C/matrix_util.f90
@@ -40,7 +40,7 @@ subroutine spral_print_matrix_i64d(lines, matrix_type, m, n, ptr, row, cval, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: base
@@ -68,7 +68,7 @@ subroutine spral_half_to_full_i64d(n, ptr, row, cval, base) bind(C)
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(inout) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(inout) :: ptr
   integer(C_INT),  dimension(*),intent(inout) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: base

--- a/interfaces/C/random.f90
+++ b/interfaces/C/random.f90
@@ -40,13 +40,13 @@ integer(C_INT) function spral_random_integer(cstate, n) bind(C)
    cstate = random_get_seed(fstate)
 end function spral_random_integer
 
-integer(C_LONG) function spral_random_long(cstate, n) bind(C)
+integer(C_LONG_LONG) function spral_random_long(cstate, n) bind(C)
    use iso_c_binding
    use spral_random
    implicit none
 
    integer(C_INT), intent(inout) :: cstate
-   integer(C_LONG), value :: n
+   integer(C_LONG_LONG), value :: n
 
    type(random_state) :: fstate
 

--- a/interfaces/C/random_matrix.f90
+++ b/interfaces/C/random_matrix.f90
@@ -69,8 +69,8 @@ integer(C_INT) function spral_random_matrix_generate_long(cstate, matrix_type, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), value :: nnz
-  integer(C_LONG), dimension(n+1), intent(out) :: ptr
+  integer(C_LONG_LONG), value :: nnz
+  integer(C_LONG_LONG), dimension(n+1), intent(out) :: ptr
   integer(C_INT), dimension(nnz), intent(out) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: flags

--- a/interfaces/C/rutherford_boeing.f90
+++ b/interfaces/C/rutherford_boeing.f90
@@ -10,7 +10,7 @@ module spral_rutherford_boeing_ciface
 
   type handle_type
      integer(C_INT), dimension(:), allocatable :: ptr32
-     integer(C_LONG), dimension(:), allocatable :: ptr64
+     integer(C_LONG_LONG), dimension(:), allocatable :: ptr64
      integer(C_INT), dimension(:), allocatable :: row
      real(C_DOUBLE), dimension(:), allocatable :: val
   end type handle_type
@@ -163,7 +163,7 @@ integer(C_INT) function spral_rb_peek(filename, m, n, nelt, nvar, nval, &
   character(len=8) :: fidentifier
 
   integer(C_INT), pointer :: temp_int
-  integer(C_LONG), pointer :: temp_long
+  integer(C_LONG_LONG), pointer :: temp_long
 
   ! Convert filename to Fortran string
   call convert_string_c2f(filename, ffilename)
@@ -344,7 +344,7 @@ integer(C_INT) function spral_rb_write(filename, matrix_type, m, n, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(n+1), target, intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(n+1), target, intent(in) :: ptr
   integer(C_INT), dimension(ptr(n+1)), target, intent(in) :: row
   type(C_PTR), value :: val
   type(spral_rb_write_options), intent(in) :: options
@@ -355,7 +355,7 @@ integer(C_INT) function spral_rb_write(filename, matrix_type, m, n, &
   character(len=:), allocatable :: ffilename, ftitle, fidentifier
   type(rb_write_options) :: foptions
   logical :: cindexed
-  integer(C_LONG), dimension(:), pointer :: fptr
+  integer(C_LONG_LONG), dimension(:), pointer :: fptr
   integer(C_INT), dimension(:), pointer :: frow
   real(C_DOUBLE), dimension(:), pointer :: fval
 

--- a/interfaces/C/scaling.f90
+++ b/interfaces/C/scaling.f90
@@ -229,7 +229,7 @@ subroutine spral_scaling_auction_sym_long(n, ptr, row, val, scaling, cmatch, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -325,7 +325,7 @@ subroutine spral_scaling_equilib_sym_long(n, ptr, row, val, scaling, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -421,7 +421,7 @@ subroutine spral_scaling_hungarian_sym_long(n, ptr, row, val, scaling, cmatch, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -544,7 +544,7 @@ subroutine spral_scaling_auction_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling
@@ -646,7 +646,7 @@ subroutine spral_scaling_equilib_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling
@@ -748,7 +748,7 @@ subroutine spral_scaling_hungarian_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG), dimension(*), intent(in) :: ptr
+  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -13,11 +13,11 @@ module spral_ssids_ciface
      integer(C_INT) :: nemin
      logical(C_BOOL) :: ignore_numa
      logical(C_BOOL) :: use_gpu
-     integer(C_LONG) :: min_gpu_work
+     integer(C_LONG_LONG) :: min_gpu_work
      real(C_FLOAT) :: max_load_inbalance
      real(C_FLOAT) :: gpu_perf_coeff
      integer(C_INT) :: scaling
-     integer(C_LONG) :: small_subtree_threshold
+     integer(C_LONG_LONG) :: small_subtree_threshold
      integer(C_INT) :: cpu_block_size
      logical(C_BOOL) :: action
      integer(C_INT) :: pivot_method
@@ -35,8 +35,8 @@ module spral_ssids_ciface
      integer(C_INT) :: maxdepth
      integer(C_INT) :: maxfront
      integer(C_INT) :: num_delay
-     integer(C_LONG) :: num_factor
-     integer(C_LONG) :: num_flops
+     integer(C_LONG_LONG) :: num_factor
+     integer(C_LONG_LONG) :: num_flops
      integer(C_INT) :: num_neg
      integer(C_INT) :: num_sup
      integer(C_INT) :: num_two
@@ -142,8 +142,8 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   type(spral_ssids_options), intent(in) :: coptions
   type(spral_ssids_inform), intent(out) :: cinform
 
-  integer(C_LONG), dimension(:), pointer :: fptr
-  integer(C_LONG), dimension(:), allocatable, target :: fptr_alloc
+  integer(C_LONG_LONG), dimension(:), pointer :: fptr
+  integer(C_LONG_LONG), dimension(:), allocatable, target :: fptr_alloc
   integer(C_INT), dimension(:), pointer :: frow
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   logical :: fcheck
@@ -324,7 +324,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
 
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
-  integer(C_LONG), value :: ne
+  integer(C_LONG_LONG), value :: ne
   type(C_PTR), value :: crow
   type(C_PTR), value :: ccol
   type(C_PTR), value :: cval
@@ -426,8 +426,8 @@ subroutine spral_ssids_factor(cposdef, cptr, crow, val, cscale, cakeep, cfkeep,&
   type(spral_ssids_inform), intent(out) :: cinform
   
   logical :: fposdef
-  integer(C_LONG), dimension(:), pointer :: fptr
-  integer(C_LONG), dimension(:), allocatable, target :: fptr_alloc
+  integer(C_LONG_LONG), dimension(:), pointer :: fptr
+  integer(C_LONG_LONG), dimension(:), allocatable, target :: fptr_alloc
   integer(C_INT), dimension(:), pointer :: frow
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   real(C_DOUBLE), dimension(:), pointer :: fscale

--- a/src/metis4_wrapper.F90
+++ b/src/metis4_wrapper.F90
@@ -10,7 +10,7 @@ module spral_metis_wrapper
   private
   public :: metis_order ! Calls metis on a symmetric matrix
 
-  integer, parameter :: long = C_LONG
+  integer, parameter :: long = C_LONG_LONG
 
   integer, parameter :: ERROR_ALLOC = -1
   integer, parameter :: ERROR_N_OOR = -2

--- a/src/metis5_wrapper.F90
+++ b/src/metis5_wrapper.F90
@@ -16,7 +16,7 @@ module spral_metis_wrapper
    private
    public :: metis_order ! Calls metis on a symmetric matrix
 
-   integer, parameter :: long = C_LONG
+   integer, parameter :: long = C_LONG_LONG
 
 #if SPRAL_HAVE_METIS_H
 ! metis header is available, check for index types 

--- a/src/ssids/cpu/cpu_iface.f90
+++ b/src/ssids/cpu/cpu_iface.f90
@@ -24,7 +24,7 @@ module spral_ssids_cpu_iface
       real(C_DOUBLE) :: small
       real(C_DOUBLE) :: u
       real(C_DOUBLE) :: multiplier
-      integer(C_LONG) :: small_subtree_threshold
+      integer(C_LONG_LONG) :: small_subtree_threshold
       integer(C_INT) :: cpu_block_size
       integer(C_INT) :: pivot_method
       integer(C_INT) :: failed_pivot_method

--- a/src/ssids/cpu/subtree.f90
+++ b/src/ssids/cpu/subtree.f90
@@ -51,10 +51,10 @@ module spral_ssids_cpu_subtree
        integer(C_INT), value :: en
        integer(C_INT), dimension(*), intent(in) :: sptr
        integer(C_INT), dimension(*), intent(in) :: sparent
-       integer(C_LONG), dimension(*), intent(in) :: rptr
+       integer(C_LONG_LONG), dimension(*), intent(in) :: rptr
        integer(C_INT), dimension(*), intent(in) :: rlist
-       integer(C_LONG), dimension(*), intent(in) :: nptr
-       integer(C_LONG), dimension(*), intent(in) :: nlist
+       integer(C_LONG_LONG), dimension(*), intent(in) :: nptr
+       integer(C_LONG_LONG), dimension(*), intent(in) :: nlist
        integer(C_INT), value :: ncontrib
        integer(C_INT), dimension(*), intent(in) :: contrib_idx
        type(cpu_factor_options), intent(in) :: options

--- a/src/ssids/gpu/datatypes.f90
+++ b/src/ssids/gpu/datatypes.f90
@@ -30,12 +30,12 @@ module spral_ssids_gpu_datatypes
 
 
    type, bind(C) :: load_nodes_type
-      integer(C_LONG) :: nnz   ! Number of entries to map
+      integer(C_LONG_LONG) :: nnz   ! Number of entries to map
       integer(C_INT) :: lda   ! Leading dimension of A
       integer(C_INT) :: ldl   ! Leading dimension of L
       type(C_PTR) :: lcol     ! Pointer to non-delay part of L
-      integer(C_LONG) :: offn  ! Offset into nlist
-      integer(C_LONG) :: offr ! Offset into rlist
+      integer(C_LONG_LONG) :: offn  ! Offset into nlist
+      integer(C_LONG_LONG) :: offr ! Offset into rlist
    end type load_nodes_type
 
    type, bind(C) :: assemble_cp_type
@@ -45,7 +45,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: cm
       integer(C_INT) :: cn
       integer(C_INT) :: ldc
-      integer(C_LONG) :: cvoffset
+      integer(C_LONG_LONG) :: cvoffset
       type(C_PTR) :: cv
       type(C_PTR) :: rlist_direct
       type(C_PTR) :: ind
@@ -61,7 +61,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: lds
       type(C_PTR) :: dval
       type(C_PTR) :: sval
-      integer(C_LONG) :: roffset
+      integer(C_LONG_LONG) :: roffset
    end type assemble_delay_type
 
    type, bind(C) :: assemble_blk_type
@@ -231,12 +231,12 @@ module spral_ssids_gpu_datatypes
       integer :: presolve = 0
       integer, dimension(:), allocatable :: lvlptr ! pointers into lvllist
       integer, dimension(:), allocatable :: lvllist ! list of nodes at level
-      integer(C_LONG), dimension(:), allocatable :: off_L ! offsets for each node
+      integer(C_LONG_LONG), dimension(:), allocatable :: off_L ! offsets for each node
       ! the following three are row offsets for independence from nrhs
       integer, dimension(:), allocatable :: off_lx ! node offsets for fwd solve
       integer, dimension(:), allocatable :: off_lc ! offsets for node contrib.
       integer, dimension(:), allocatable :: off_ln ! node offsets for bwd solve
-      integer(C_LONG) :: rd_size = 0
+      integer(C_LONG_LONG) :: rd_size = 0
       integer :: max_lx_size = 0
       integer :: max_lc_size = 0
       type(eltree_level), dimension(:), allocatable :: values_L(:) ! data
@@ -315,7 +315,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: first
       type(C_PTR) :: lval
       type(C_PTR) :: ldval
-      integer(C_LONG) :: offc
+      integer(C_LONG_LONG) :: offc
       integer(C_INT) :: n
       integer(C_INT) :: k
       integer(C_INT) :: lda
@@ -342,7 +342,7 @@ module spral_ssids_gpu_datatypes
     integer(C_INT) :: ncols
     integer(C_INT) :: nrhs
     integer(C_INT) :: offb
-    integer(C_LONG) :: off_a
+    integer(C_LONG_LONG) :: off_a
     integer(C_INT) :: off_b
     integer(C_INT) :: off_u
     integer(C_INT) :: off_v

--- a/src/ssids/gpu/interfaces.f90
+++ b/src/ssids/gpu/interfaces.f90
@@ -74,7 +74,7 @@ module spral_ssids_gpu_interfaces
          implicit none
          type(C_PTR), value :: stream
          integer(C_INT), intent(in), value :: nb
-         integer(C_LONG), intent(in), value :: n
+         integer(C_LONG_LONG), intent(in), value :: n
          type(C_PTR), value :: array
          type(C_PTR), value :: buff
          type(C_PTR), value :: maxabs

--- a/src/ssids/gpu/subtree.f90
+++ b/src/ssids/gpu/subtree.f90
@@ -242,7 +242,7 @@ contains
       rlist_direct, gpu_nlist, gpu_rlist, gpu_rlist_direct, cuda_error)
    implicit none
    integer(long), intent(in) :: lnlist
-   integer(C_LONG), dimension(lnlist), target, intent(in) :: nlist
+   integer(C_LONG_LONG), dimension(lnlist), target, intent(in) :: nlist
    integer(long), intent(in) :: lrlist
    integer(C_INT), dimension(lrlist), target, intent(in) :: rlist
    integer(C_INT), dimension(lrlist), target, intent(in) :: rlist_direct

--- a/src/timer.f90
+++ b/src/timer.f90
@@ -7,7 +7,7 @@ module spral_timespec
 
    type, bind(C) :: timespec
       integer(C_INT) :: tv_sec
-      integer(C_LONG) :: tv_nsec
+      integer(C_LONG_LONG) :: tv_nsec
    end type timespec
 end module spral_timespec
 


### PR DESCRIPTION
C_LONG == C_INT on Windows and 32 bits platforms.