### PR TITLE
Remove the -lrt linking in makefiles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,19 +35,11 @@ AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
 
 # FIXME: make below configurable
 if HAVE_NVCC
-if BUILD_WINDOWS
 LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS)
-else
-LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) -L$(CUDA_HOME)/lib64 $(HWLOC_LIBS) $(FCLIBS) -lrt
-endif
 SPRAL_LINK_LIBS = -lcublas
 SPRALLINK = $(NVCCLINK)
 else
-if BUILD_WINDOWS
 LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS)
-else
-LDADD = -L. -lspral $(METIS_LIBS) $(LAPACK_LIBS) $(BLAS_LIBS) $(GTG_LIBS) $(HWLOC_LIBS) $(FCLIBS) -lrt
-endif
 SPRAL_LINK_LIBS = $(CXXLIB)
 SPRALLINK = $(FCLINK)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -3,19 +3,6 @@ AC_CONFIG_SRCDIR([src/ssids/ssids.f90])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE
 
-# AC_CANONICAL_HOST is needed to access the 'host_os' variable
-AC_CANONICAL_HOST
-
-build_windows=no
-case "${host_os}" in
-	cygwin*|mingw*)
-		build_windows=yes
-		;;
-esac
-
-# Pass the conditional to automake
-AM_CONDITIONAL([BUILD_WINDOWS], [test "$build_windows" = "yes"])
-
 # Allow disabling of OpenMP
 AC_ARG_ENABLE([openmp],
    AS_HELP_STRING([--disable-openmp], [Disable OpenMP parallelism. Not recommended.])


### PR DESCRIPTION
This dependency is no longer required and is included in the std lib