### PR TITLE
Disable dot file generation

### DIFF
--- a/src/ssids/anal.f90
+++ b/src/ssids/anal.f90
@@ -1036,8 +1036,8 @@ contains
 
     ! Generate dot file for assembly tree
     ! call print_atree(akeep%nnodes, akeep%sptr, akeep%sparent, akeep%rptr)
-    call print_atree_part(akeep%nnodes, akeep%sptr, akeep%sparent, akeep%rptr, &
-         akeep%topology, akeep%nparts, akeep%part, exec_loc)
+    !call print_atree_part(akeep%nnodes, akeep%sptr, akeep%sparent, akeep%rptr, &
+    !     akeep%topology, akeep%nparts, akeep%part, exec_loc)
 
     ! Construct symbolic subtrees
     allocate(akeep%subtree(akeep%nparts))


### PR DESCRIPTION
It's a little irritating to me that a file that seems to be for diagnostiscs is created unconditionally. If commenting out is not desired maybe it could be tied to a runtime or compiletime option instead?