### PR TITLE
Pass scale from ptr32 wrapper only if present

### DIFF
--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -753,8 +753,13 @@ contains
     ptr64(1:akeep%n+1) = ptr(1:akeep%n+1)
 
     ! Call 64-bit routine
-    call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
-         inform, scale=scale, ptr=ptr64, row=row)
+    if (present(scale)) then
+      call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+           inform, scale=scale, ptr=ptr64, row=row)
+    else
+      call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+           inform, ptr=ptr64, row=row)
+    end if
   end subroutine ssids_factor_ptr32_double
 
 !****************************************************************************


### PR DESCRIPTION
This was flagged for me by undefined behaviour sanitizer. Haven't seen this causing actual bugs yet, but I'd argue this is still more correct.