### PR TITLE
Allow disabling some print output

### DIFF
--- a/src/ssids/anal.f90
+++ b/src/ssids/anal.f90
@@ -364,8 +364,9 @@ contains
        if (st .ne. 0) return
     end do
 
-    if (options%print_level >= 0) then
-       print *, "[find_subtree_partition] load_balance = ", best_load_balance
+    if ((options%print_level .ge. 1) .and. (options%unit_diagnostics .ge. 0)) then
+       write (options%unit_diagnostics,*) &
+            "[find_subtree_partition] load_balance = ", best_load_balance
     end if
     ! Consolidate adjacent non-children nodes into same part and regen exec_alloc
     !print *
@@ -1014,12 +1015,14 @@ contains
     if (st .ne. 0) go to 100
 
     ! Sort out subtrees
-    if (options%print_level >= 0) then
-       print *, "Input topology"
+    if ((options%print_level .ge. 1) .and. (options%unit_diagnostics .ge. 0)) then
+       write (options%unit_diagnostics,*) "Input topology"
        do i = 1, size(akeep%topology)
-         print *, "Region ", i, " with ", akeep%topology(i)%nproc, " cores"
+         write (options%unit_diagnostics,*) &
+              "Region ", i, " with ", akeep%topology(i)%nproc, " cores"
          if(size(akeep%topology(i)%gpus).gt.0) &
-            print *, "---> gpus ", akeep%topology(i)%gpus
+            write (options%unit_diagnostics,*) &
+                 "---> gpus ", akeep%topology(i)%gpus
        end do
     end if
     call find_subtree_partition(akeep%nnodes, akeep%sptr, akeep%sparent,           &

--- a/src/ssids/anal.f90
+++ b/src/ssids/anal.f90
@@ -364,7 +364,9 @@ contains
        if (st .ne. 0) return
     end do
 
-    print *, "[find_subtree_partition] load_balance = ", best_load_balance 
+    if (options%print_level >= 0) then
+       print *, "[find_subtree_partition] load_balance = ", best_load_balance
+    end if
     ! Consolidate adjacent non-children nodes into same part and regen exec_alloc
     !print *
     !print *, "pre merge", part(1:nparts+1)
@@ -1012,12 +1014,14 @@ contains
     if (st .ne. 0) go to 100
 
     ! Sort out subtrees
-    print *, "Input topology"
-    do i = 1, size(akeep%topology)
-      print *, "Region ", i, " with ", akeep%topology(i)%nproc, " cores"
-      if(size(akeep%topology(i)%gpus).gt.0) &
-         print *, "---> gpus ", akeep%topology(i)%gpus
-    end do
+    if (options%print_level >= 0) then
+       print *, "Input topology"
+       do i = 1, size(akeep%topology)
+         print *, "Region ", i, " with ", akeep%topology(i)%nproc, " cores"
+         if(size(akeep%topology(i)%gpus).gt.0) &
+            print *, "---> gpus ", akeep%topology(i)%gpus
+       end do
+    end if
     call find_subtree_partition(akeep%nnodes, akeep%sptr, akeep%sparent,           &
          akeep%rptr, options, akeep%topology, akeep%nparts, akeep%part,            &
          exec_loc, akeep%contrib_ptr, akeep%contrib_idx, contrib_dest, inform, st)


### PR DESCRIPTION
Guard some prints in symbolic analysis with `options%print_level` to allow avoiding that output.