### PR TITLE
Allow compilation without profiling

### DIFF
--- a/src/ssids/fkeep.F90
+++ b/src/ssids/fkeep.F90
@@ -14,7 +14,9 @@ module spral_ssids_fkeep
    use spral_ssids_inform, only : ssids_inform
    use spral_ssids_subtree, only : numeric_subtree_base
    use spral_ssids_cpu_subtree, only : cpu_numeric_subtree
-   use spral_ssids_profile, only : profile_begin, profile_end, profile_add_event 
+#ifdef PROFILE
+   use spral_ssids_profile, only : profile_begin, profile_end, profile_add_event
+#endif
    implicit none
 
    private

--- a/src/ssids/fkeep.F90
+++ b/src/ssids/fkeep.F90
@@ -67,8 +67,10 @@ subroutine inner_factor_cpu(fkeep, akeep, val, options, inform)
   type(contrib_type), dimension(:), allocatable :: child_contrib
   type(ssids_inform), dimension(:), allocatable :: thread_inform
 
+#ifdef PROFILE
   ! Begin profile trace (noop if not enabled)
   call profile_begin(akeep%topology)
+#endif
 
   ! Allocate space for subtrees
   allocate(fkeep%subtree(akeep%nparts), stat=inform%stat)
@@ -174,9 +176,11 @@ subroutine inner_factor_cpu(fkeep, akeep, val, options, inform)
   if (inform%flag.lt.0) goto 100 ! cleanup and exit
 
   if (all_region) then
-     
+
+#ifdef PROFILE
      ! At least some all region subtrees exist
      call profile_add_event("EV_ALL_REGIONS", "Starting processing root subtree", 0)
+#endif
      
      !$omp parallel num_threads(total_threads) default(shared)
      !$omp single
@@ -208,8 +212,10 @@ subroutine inner_factor_cpu(fkeep, akeep, val, options, inform)
 
 100 continue ! cleanup and exit
 
+#ifdef PROFILE
   ! End profile trace (noop if not enabled)
   call profile_end()
+#endif
 
   return
 

--- a/src/ssids/profile.hxx
+++ b/src/ssids/profile.hxx
@@ -239,11 +239,13 @@ private:
       return thread_name[thread];
    }
 
+#ifdef PROFILE
    /** \brief Return difference in seconds between t1 and t2. */
    static
    double tdiff(struct timespec t1, struct timespec t2) {
       return (t2.tv_sec - t1.tv_sec) + 1e-9*(t2.tv_nsec - t1.tv_nsec);
    }
+#endif
 
    /** \brief Return best guess at processor id. */
    static


### PR DESCRIPTION
Fix and expand use of `PROFILE` macro to allow compilation without profiling code.