### PR TITLE
Pass optional parameters only if present

### DIFF
--- a/src/match_order.f90
+++ b/src/match_order.f90
@@ -452,7 +452,11 @@ contains
     end do
     ptr2(n+1) = k
 
-    call mo_match(n,row2,ptr2,val2,scale,flag,stat,perm=perm)
+    if (present(perm)) then
+       call mo_match(n,row2,ptr2,val2,scale,flag,stat,perm=perm)
+    else
+       call mo_match(n,row2,ptr2,val2,scale,flag,stat)
+    end if
     if (flag .lt. 0) return
 
     if (struct_rank .ne. n) then

--- a/src/scaling.f90
+++ b/src/scaling.f90
@@ -127,8 +127,13 @@ contains
     end if
     ptr64(1:n+1) = ptr(1:n+1)
 
-    call hungarian_scale_sym_int64(n, ptr64, row, val, scaling, options, &
-         inform, match=match)
+    if (present(match)) then
+       call hungarian_scale_sym_int64(n, ptr64, row, val, scaling, options, &
+            inform, match=match)
+    else
+       call hungarian_scale_sym_int64(n, ptr64, row, val, scaling, options, &
+            inform)
+    end if
   end subroutine hungarian_scale_sym_int32
   
   subroutine hungarian_scale_sym_int64(n, ptr, row, val, scaling, options, &
@@ -197,8 +202,13 @@ contains
     end if
     ptr64(1:n+1) = ptr(1:n+1)
 
-    call hungarian_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
-         options, inform, match=match)
+    if (present(match)) then
+       call hungarian_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
+            options, inform, match=match)
+    else
+       call hungarian_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
+            options, inform)
+    end if
   end subroutine hungarian_scale_unsym_int32
 
   subroutine hungarian_scale_unsym_int64(m, n, ptr, row, val, rscaling, cscaling,&
@@ -262,8 +272,12 @@ contains
     end if
     ptr64(1:n+1) = ptr(1:n+1)
 
-    call auction_scale_sym_int64(n, ptr64, row, val, scaling, options, inform, &
-         match=match)
+    if (present(match)) then
+       call auction_scale_sym_int64(n, ptr64, row, val, scaling, options, inform, &
+            match=match)
+    else
+       call auction_scale_sym_int64(n, ptr64, row, val, scaling, options, inform)
+    end if
   end subroutine auction_scale_sym_int32
 
   subroutine auction_scale_sym_int64(n, ptr, row, val, scaling, options, inform, &
@@ -335,8 +349,13 @@ contains
     end if
     ptr64(1:n+1) = ptr(1:n+1)
 
-    call auction_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
-         options, inform, match=match)
+    if (present(match)) then
+       call auction_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
+            options, inform, match=match)
+    else
+       call auction_scale_unsym_int64(m, n, ptr64, row, val, rscaling, cscaling, &
+            options, inform)
+    end if
   end subroutine auction_scale_unsym_int32
   
   subroutine auction_scale_unsym_int64(m, n, ptr, row, val, rscaling, cscaling, &

--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -103,10 +103,17 @@ contains
     if (stats%st .ne. 0) goto 100
 
     ! Perform actual factorization
-    call subtree_factor_gpu(stream_handle, pos_def, child_ptr, child_list, &
-      n, nptr, gpu_nlist, ptr_val, nnodes, nodes, sptr, sparent, rptr,     &
-      rlist_direct, gpu_rlist, gpu_rlist_direct, gpu_contribs, gpu_LDLT,   &
-      stream_data, alloc, options, stats, ptr_scale)
+    if (present(ptr_scale)) then
+       call subtree_factor_gpu(stream_handle, pos_def, child_ptr, child_list, &
+         n, nptr, gpu_nlist, ptr_val, nnodes, nodes, sptr, sparent, rptr,     &
+         rlist_direct, gpu_rlist, gpu_rlist_direct, gpu_contribs, gpu_LDLT,   &
+         stream_data, alloc, options, stats, ptr_scale)
+    else
+       call subtree_factor_gpu(stream_handle, pos_def, child_ptr, child_list, &
+         n, nptr, gpu_nlist, ptr_val, nnodes, nodes, sptr, sparent, rptr,     &
+         rlist_direct, gpu_rlist, gpu_rlist_direct, gpu_contribs, gpu_LDLT,   &
+         stream_data, alloc, options, stats)
+    end if
     if (stats%flag .lt. 0) return
     if (stats%cuda_error .ne. 0) goto 200
     
@@ -509,9 +516,15 @@ contains
        end do
 
        ! Initialize L to 0, and add A to it.
-       call init_L_with_A(stream, lev, gpu%lvlptr, gpu%lvllist, nodes, ncb,  &
-            level_size, nptr, rptr, gpu_nlist, gpu_rlist, ptr_val, ptr_levL, &
-            gwork, stats%st, stats%cuda_error, ptr_scale=ptr_scale)
+       if (present(ptr_scale)) then
+          call init_L_with_A(stream, lev, gpu%lvlptr, gpu%lvllist, nodes, ncb,  &
+               level_size, nptr, rptr, gpu_nlist, gpu_rlist, ptr_val, ptr_levL, &
+               gwork, stats%st, stats%cuda_error, ptr_scale=ptr_scale)
+       else
+          call init_L_with_A(stream, lev, gpu%lvlptr, gpu%lvllist, nodes, ncb,  &
+               level_size, nptr, rptr, gpu_nlist, gpu_rlist, ptr_val, ptr_levL, &
+               gwork, stats%st, stats%cuda_error)
+       end if
        if (stats%st .ne. 0) goto 100
        if (stats%cuda_error .ne. 0) goto 200
 

--- a/src/ssids/gpu/subtree.f90
+++ b/src/ssids/gpu/subtree.f90
@@ -762,7 +762,15 @@ contains
 
    if (this%host_factors) then
       ! Call CPU version instead
-      call enquire_indef_gpu_cpu(this, piv_order=piv_order, d=d)
+      if (present(piv_order) .and. present(d)) then
+         call enquire_indef_gpu_cpu(this, piv_order=piv_order, d=d)
+      else if (present(piv_order)) then
+         call enquire_indef_gpu_cpu(this, piv_order=piv_order)
+      else if (present(d)) then
+         call enquire_indef_gpu_cpu(this, d=d)
+      else
+         call enquire_indef_gpu_cpu(this)
+      end if
       return
    end if
 

--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -117,8 +117,30 @@ contains
     ptr64(1:n+1) = ptr(1:n+1)
 
     ! Call 64-bit version of routine
-    call analyse_double(check, n, ptr64, row, akeep, options, inform, &
-         order=order, val=val, topology=topology)
+    if (present(order) .and. present(val) .and. present(topology)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            order=order, val=val, topology=topology)
+    else if (present(order) .and. present(val)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            order=order, val=val)
+    else if (present(order) .and. present(topology)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            order=order, topology=topology)
+    else if (present(val) .and. present(topology)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            val=val, topology=topology)
+    else if (present(order)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            order=order)
+    else if (present(val)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            val=val)
+    else if (present(topology)) then
+       call analyse_double(check, n, ptr64, row, akeep, options, inform, &
+            topology=topology)
+    else
+       call analyse_double(check, n, ptr64, row, akeep, options, inform)
+    end if
   end subroutine analyse_double_ptr32
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -753,12 +775,18 @@ contains
     ptr64(1:akeep%n+1) = ptr(1:akeep%n+1)
 
     ! Call 64-bit routine
-    if (present(scale)) then
-      call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
-           inform, scale=scale, ptr=ptr64, row=row)
+    if (present(scale) .and. present(row)) then
+       call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+            inform, scale=scale, ptr=ptr64, row=row)
+    else if (present(scale)) then
+       call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+            inform, scale=scale, ptr=ptr64)
+    else if (present(row)) then
+       call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+            inform, ptr=ptr64, row=row)
     else
-      call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
-           inform, ptr=ptr64, row=row)
+       call ssids_factor_ptr64_double(posdef, val, akeep, fkeep, options, &
+            inform, ptr=ptr64)
     end if
   end subroutine ssids_factor_ptr32_double
 


### PR DESCRIPTION
Optional parameters were passed down to further functions unconditionally in some places. That is not legal for parameters that are not present. This adds the checks for that.

Follow-up on #55.