### PR TITLE
Fix wrong nemin default value in C documentation

### DIFF
--- a/doc/C/ssids.rst
+++ b/doc/C/ssids.rst
@@ -434,7 +434,7 @@ Derived types
       Supernode amalgamation threshold. Two neighbours in the elimination tree
       are merged if they both involve fewer than `nemin` eliminations.
       The default is used if `nemin<1`.
-      The default is 8.
+      The default is 32.
 
    .. c:member bool ignore_numa:
    


### PR DESCRIPTION
According to https://github.com/ralna/spral/blob/6c5692454b1bb42328dd5203c9cb042bc759468b/src/ssids/datatypes.f90#L21
the default value for `nemin` is actually `32`. It is correct in the Fortran documentation.