### PR TITLE
Fix n = 0 case for C interface of SSIDS

### DIFF
--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -46,6 +46,9 @@ module spral_ssids_ciface
      character(C_CHAR) :: unused(80)
   end type spral_ssids_inform
 
+  integer(C_INT), target :: spral_ssids_empty_dummy_array_int(0)
+  real(C_DOUBLE), target :: spral_ssids_empty_dummy_array_double(0)
+
 contains
   subroutine copy_options_in(coptions, foptions, cindexed)
     implicit none
@@ -184,7 +187,7 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   if (C_ASSOCIATED(crow)) then
      call C_F_POINTER(crow, frow, shape=(/ fptr(n+1)-1 /))
   else
-     nullify(frow)
+     frow => spral_ssids_empty_dummy_array_int
   end if
   if (cindexed) then
      allocate(frow_alloc(fptr(n+1)-1))
@@ -288,7 +291,7 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   if (C_ASSOCIATED(crow)) then
      call C_F_POINTER(crow, frow, shape=(/ fptr(n+1)-1 /))
   else
-     nullify(frow)
+     frow => spral_ssids_empty_dummy_array_int
   end if
   if (cindexed) then
      allocate(frow_alloc(fptr(n+1)-1))
@@ -380,7 +383,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   if (C_ASSOCIATED(crow)) then
      call C_F_POINTER(crow, frow, shape=(/ ne /))
   else
-     nullify(frow)
+     frow => spral_ssids_empty_dummy_array_int
   end if
   if (cindexed) then
      allocate(frow_alloc(ne))
@@ -390,7 +393,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   if (C_ASSOCIATED(ccol)) then
      call C_F_POINTER(ccol, fcol, shape=(/ ne /))
   else
-     nullify(fcol)
+     fcol => spral_ssids_empty_dummy_array_int
   end if
   if (cindexed) then
      allocate(fcol_alloc(ne))
@@ -648,7 +651,7 @@ subroutine spral_ssids_solve1(job, cx1, cakeep, cfkeep, coptions, cinform) &
   if (C_ASSOCIATED(cx1)) then
      call C_F_POINTER(cx1, fx1, shape=(/ fakeep%n /))
   else
-     nullify(fx1)
+     fx1 => spral_ssids_empty_dummy_array_double
   end if
 
   ! Call Fortran routine
@@ -692,7 +695,7 @@ subroutine spral_ssids_solve(job, nrhs, cx, ldx, cakeep, cfkeep, coptions, &
   if (C_ASSOCIATED(cx)) then
      call C_F_POINTER(cx, fx, shape=(/ ldx,nrhs /))
   else
-     nullify(fx)
+     fx(1:ldx,1:nrhs) => spral_ssids_empty_dummy_array_double
   end if
   if (C_ASSOCIATED(cakeep)) then
      call C_F_POINTER(cakeep, fakeep)


### PR DESCRIPTION
A valid C implementation [may return `NULL` for `malloc(0)`](https://en.cppreference.com/w/c/memory/malloc). In that sense, zero-length arrays may be represented by a null pointer in C. When those are passed to the C interface of SSIDS, they are detected as not `C_ASSOCIATED`, and the corresponding Fortran pointers are nullified. A few of those nullified Fortran pointers are then used illegally without further checks. To fix this, I propose to associate those Fortran pointers to empty arrays instead of disassociating them with `nullify`.

The problem can be observed for example by setting
```c
int n = 0;
long ptr[1] = {options.array_base};
int *row = NULL;
double *val = NULL;
double *x = NULL; 
```
in [examples/C/ssids.c](https://github.com/ralna/spral/blob/e9c57c0062e1d93754cf23906ca4588296abf28f/examples/C/ssids.c). A few issues about uninitialized values are reported by valgrind when running the example with these modifications. When additionally setting `options.array_base = 0`, the example segfaults.

Admittedly this is a pretty special case, also because it seems like gcc happens to not return `NULL` for `malloc(0)`. But I do actually run into this issue when calling the library from C++, where (at least with g++) `nullptr` for "empty sequence" comes up quite frequently, e.g. when using `std::array<int, 0>` or other containers like `std::vector` constructed with size 0. That's why I'd like to make it work with `NULL` as function arguments for the n = 0 case.