### PR TITLE
Fix n = 0 case for C interface of SSIDS

### DIFF
--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -135,12 +135,12 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   logical(C_BOOL), value :: ccheck
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
-  type(C_PTR), value :: cptr
-  type(C_PTR), value :: crow
+  integer(C_LONG_LONG), target, dimension(n+1) :: cptr
   type(C_PTR), value :: cval
   type(C_PTR), intent(inout) :: cakeep
   type(spral_ssids_options), intent(in) :: coptions
   type(spral_ssids_inform), intent(out) :: cinform
+  integer(C_INT), target, dimension(cptr(n+1)-coptions%array_base) :: crow
 
   integer(C_LONG_LONG), dimension(:), pointer :: fptr
   integer(C_LONG_LONG), dimension(:), allocatable, target :: fptr_alloc
@@ -171,21 +171,13 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
      forder_alloc(:) = forder(:) + 1
      forder => forder_alloc
   endif
-  if (C_ASSOCIATED(cptr)) then
-     call C_F_POINTER(cptr, fptr, shape=(/ n+1 /))
-  else
-     nullify(fptr)
-  end if
+  fptr => cptr
   if (cindexed) then
      allocate(fptr_alloc(n+1))
      fptr_alloc(:) = fptr(:) + 1
      fptr => fptr_alloc
   end if
-  if (C_ASSOCIATED(crow)) then
-     call C_F_POINTER(crow, frow, shape=(/ fptr(n+1)-1 /))
-  else
-     nullify(frow)
-  end if
+  frow => crow
   if (cindexed) then
      allocate(frow_alloc(fptr(n+1)-1))
      frow_alloc(:) = frow(:) + 1
@@ -239,12 +231,12 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
   logical(C_BOOL), value :: ccheck
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
-  type(C_PTR), value :: cptr
-  type(C_PTR), value :: crow
+  integer(C_INT), target, dimension(n+1) :: cptr
   type(C_PTR), value :: cval
   type(C_PTR), intent(inout) :: cakeep
   type(spral_ssids_options), intent(in) :: coptions
   type(spral_ssids_inform), intent(out) :: cinform
+  integer(C_INT), target, dimension(cptr(n+1)-coptions%array_base) :: crow
 
   integer(C_INT), dimension(:), pointer :: fptr
   integer(C_INT), dimension(:), allocatable, target :: fptr_alloc
@@ -275,21 +267,13 @@ subroutine spral_ssids_analyse_ptr32(ccheck, n, corder, cptr, crow, cval, &
      forder_alloc(:) = forder(:) + 1
      forder => forder_alloc
   endif
-  if (C_ASSOCIATED(cptr)) then
-     call C_F_POINTER(cptr, fptr, shape=(/ n+1 /))
-  else
-     nullify(fptr)
-  end if
+  fptr => cptr
   if (cindexed) then
      allocate(fptr_alloc(n+1))
      fptr_alloc(:) = fptr(:) + 1
      fptr => fptr_alloc
   end if
-  if (C_ASSOCIATED(crow)) then
-     call C_F_POINTER(crow, frow, shape=(/ fptr(n+1)-1 /))
-  else
-     nullify(frow)
-  end if
+  frow => crow
   if (cindexed) then
      allocate(frow_alloc(fptr(n+1)-1))
      frow_alloc(:) = frow(:) + 1
@@ -343,8 +327,8 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
   integer(C_LONG_LONG), value :: ne
-  type(C_PTR), value :: crow
-  type(C_PTR), value :: ccol
+  integer(C_INT), target, dimension(ne) :: crow
+  integer(C_INT), target, dimension(ne) :: ccol
   type(C_PTR), value :: cval
   type(C_PTR), intent(inout) :: cakeep
   type(spral_ssids_options), intent(in) :: coptions
@@ -377,21 +361,13 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
      forder_alloc(:) = forder(:) + 1
      forder => forder_alloc
   endif
-  if (C_ASSOCIATED(crow)) then
-     call C_F_POINTER(crow, frow, shape=(/ ne /))
-  else
-     nullify(frow)
-  end if
+  frow => crow
   if (cindexed) then
      allocate(frow_alloc(ne))
      frow_alloc(:) = frow(:) + 1
      frow => frow_alloc
   end if
-  if (C_ASSOCIATED(ccol)) then
-     call C_F_POINTER(ccol, fcol, shape=(/ ne /))
-  else
-     nullify(fcol)
-  end if
+  fcol => ccol
   if (cindexed) then
      allocate(fcol_alloc(ne))
      fcol_alloc(:) = fcol(:) + 1
@@ -617,7 +593,7 @@ subroutine spral_ssids_solve1(job, cx1, cakeep, cfkeep, coptions, cinform) &
   implicit none
 
   integer(C_INT), value :: job
-  type(C_PTR), value :: cx1
+  real(C_DOUBLE), target, dimension(*) :: cx1
   type(C_PTR), value :: cakeep
   type(C_PTR), value :: cfkeep
   type(spral_ssids_options), intent(in) :: coptions
@@ -645,11 +621,7 @@ subroutine spral_ssids_solve1(job, cx1, cakeep, cfkeep, coptions, cinform) &
   else
      nullify(ffkeep)
   end if
-  if (C_ASSOCIATED(cx1)) then
-     call C_F_POINTER(cx1, fx1, shape=(/ fakeep%n /))
-  else
-     nullify(fx1)
-  end if
+  fx1 => cx1(1:fakeep%n)
 
   ! Call Fortran routine
   if (job .eq. 0) then
@@ -663,21 +635,20 @@ subroutine spral_ssids_solve1(job, cx1, cakeep, cfkeep, coptions, cinform) &
   call copy_inform_out(finform, cinform)
 end subroutine spral_ssids_solve1
 
-subroutine spral_ssids_solve(job, nrhs, cx, ldx, cakeep, cfkeep, coptions, &
+subroutine spral_ssids_solve(job, nrhs, x, ldx, cakeep, cfkeep, coptions, &
      cinform) bind(C)
   use spral_ssids_ciface
   implicit none
 
   integer(C_INT), value :: job
   integer(C_INT), value :: nrhs
-  type(C_PTR), value :: cx
+  real(C_DOUBLE), dimension(ldx,nrhs) :: x
   integer(C_INT), value :: ldx
   type(C_PTR), value :: cakeep
   type(C_PTR), value :: cfkeep
   type(spral_ssids_options), intent(in) :: coptions
   type(spral_ssids_inform), intent(out) :: cinform
 
-  real(C_DOUBLE), dimension(:,:), pointer :: fx
   type(ssids_akeep), pointer :: fakeep
   type(ssids_fkeep), pointer :: ffkeep
   type(ssids_options) :: foptions
@@ -689,11 +660,6 @@ subroutine spral_ssids_solve(job, nrhs, cx, ldx, cakeep, cfkeep, coptions, &
   call copy_options_in(coptions, foptions, cindexed)
 
   ! Translate arguments
-  if (C_ASSOCIATED(cx)) then
-     call C_F_POINTER(cx, fx, shape=(/ ldx,nrhs /))
-  else
-     nullify(fx)
-  end if
   if (C_ASSOCIATED(cakeep)) then
      call C_F_POINTER(cakeep, fakeep)
   else
@@ -707,9 +673,9 @@ subroutine spral_ssids_solve(job, nrhs, cx, ldx, cakeep, cfkeep, coptions, &
 
   ! Call Fortran routine
   if (job .eq. 0) then
-     call ssids_solve(nrhs, fx, ldx, fakeep, ffkeep, foptions, finform)
+     call ssids_solve(nrhs, x, ldx, fakeep, ffkeep, foptions, finform)
   else
-     call ssids_solve(nrhs, fx, ldx, fakeep, ffkeep, foptions, finform, job=job)
+     call ssids_solve(nrhs, x, ldx, fakeep, ffkeep, foptions, finform, job=job)
   end if
 
   ! Copy arguments out


### PR DESCRIPTION
A valid C implementation [may return NULL for malloc(0)](https://en.cppreference.com/w/c/memory/malloc). In that sense, zero-length arrays may be represented by a null pointer in C. When those are passed to the C interface of SSIDS, they are detected as not C_ASSOCIATED, and the corresponding Fortran pointers are nullified. A few of those nullified Fortran pointers are then used illegally without further checks. To fix this, I propose to avoid checking for C_ASSOCIATED altogether by declaring the C arguments as arrays directly.

The problem can be observed for example by setting
```c
int n = 0;
long ptr[1] = {options.array_base};
int *row = NULL;
double *val = NULL;
double *x = NULL; 
```
in [examples/C/ssids.c](https://github.com/ralna/spral/blob/e9c57c0062e1d93754cf23906ca4588296abf28f/examples/C/ssids.c). A few issues about uninitialized values are reported by valgrind when running the example with these modifications. When additionally setting `options.array_base = 0`, the example segfaults.

See #82 for a discussion on a different solution that led to this simplified one.