### PR TITLE
Standard conforming BLAS/LAPACK calls from C

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,11 +112,6 @@ AS_IF([test "x$enable_profile" == "xyes"], [
    echo "Bite me $enable_profile"
    ])
 
-# Fix for broken CBLAS/LAPACKE (see https://lwn.net/Articles/791393/)
-AC_LANG_PUSH(Fortran)
-AX_APPEND_COMPILE_FLAGS([-fno-optimize-sibling-calls])
-AC_LANG_POP(Fortran)
-
 # Output data
 AC_CONFIG_FILES(Makefile)
 AC_OUTPUT

--- a/src/blas_iface.f90
+++ b/src/blas_iface.f90
@@ -5,7 +5,8 @@ module spral_blas_iface
   private
   public :: daxpy, dcopy, ddot, dnrm2, dscal
   public :: zaxpy, zcopy, zdotc, dznrm2, zscal
-  public :: dgemm, dtrsm
+  public :: dgemv, dtrsv
+  public :: dgemm, dsyrk, dtrsm
   public :: zgemm, ztrsm
 
   ! Level 1 BLAS
@@ -78,6 +79,26 @@ module spral_blas_iface
     end subroutine zaxpy
   end interface
 
+  ! Level 2 BLAS
+  interface
+    subroutine dgemv( trans, m, n, alpha, a, lda, x, incx, beta, y, incy )
+      implicit none
+      character, intent(in) :: trans
+      integer, intent(in) :: m, n, lda, incx, incy
+      double precision, intent(in) :: alpha, beta
+      double precision, intent(in   ), dimension(lda, n) :: a
+      double precision, intent(in   ), dimension(*) :: x
+      double precision, intent(inout), dimension(*) :: y
+    end subroutine dgemv
+    subroutine dtrsv( uplo, trans, diag, n, a, lda, x, incx )
+      implicit none
+      character, intent(in) :: uplo, trans, diag
+      integer, intent(in) :: n, lda, incx
+      double precision, intent(in   ), dimension(lda, n) :: a
+      double precision, intent(inout), dimension(*) :: x
+    end subroutine dtrsv
+  end interface
+
   ! Level 3 BLAS
   interface
     subroutine dgemm( ta, tb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc )
@@ -90,6 +111,14 @@ module spral_blas_iface
       double precision, intent(in   ), dimension(ldb, *) :: b
       double precision, intent(inout), dimension(ldc, *) :: c
     end subroutine dgemm
+    subroutine dsyrk( uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+      implicit none
+      character, intent(in) :: uplo, trans
+      integer, intent(in) :: n, k, lda, ldc
+      double precision, intent(in) :: alpha, beta
+      double precision, intent(in   ), dimension(lda, *) :: a
+      double precision, intent(inout), dimension(ldc, n) :: c
+    end subroutine dsyrk
     subroutine dtrsm( side, uplo, trans, diag, m, n, alpha, a, lda, b, ldb )
       implicit none
       character, intent(in) :: side, uplo, trans, diag

--- a/src/lapack_iface.f90
+++ b/src/lapack_iface.f90
@@ -3,7 +3,7 @@ module spral_lapack_iface
   implicit none
 
   private
-  public :: dpotrf, dlacpy
+  public :: dpotrf, dlacpy, dsytrf
   public :: zpotrf, zlacpy
 
   interface
@@ -21,6 +21,15 @@ module spral_lapack_iface
       double precision, intent(in ) :: a(lda, n)
       double precision, intent(out) :: b(ldb, n)
     end subroutine dlacpy
+    subroutine dsytrf( uplo, n, a, lda, ipiv, work, lwork, info )
+      implicit none
+      character, intent(in) :: uplo
+      integer, intent(in) :: n, lda, lwork
+      integer, intent(out), dimension(n) :: ipiv
+      integer, intent(out) :: info
+      double precision, intent(inout), dimension(lda, *) :: a
+      double precision, intent(out  ), dimension(*) :: work
+    end subroutine dsytrf
   end interface
 
   interface

--- a/src/ssids/cpu/cpu_iface.f90
+++ b/src/ssids/cpu/cpu_iface.f90
@@ -87,4 +87,83 @@ subroutine cpu_copy_stats_out(cstats, finform)
    finform%matrix_rank  = finform%matrix_rank - cstats%num_zero
 end subroutine cpu_copy_stats_out
 
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!> @brief Wrapper functions for BLAS/LAPACK routines for standard conforming
+!> interop calls from C.
+subroutine spral_c_dgemm(ta, tb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc) &
+bind(C)
+   use spral_blas_iface, only : dgemm
+   character(C_CHAR), intent(in) :: ta, tb
+   integer(C_INT), intent(in) :: m, n, k
+   integer(C_INT), intent(in) :: lda, ldb, ldc
+   real(C_DOUBLE), intent(in) :: alpha, beta
+   real(C_DOUBLE), intent(in   ), dimension(lda, *) :: a
+   real(C_DOUBLE), intent(in   ), dimension(ldb, *) :: b
+   real(C_DOUBLE), intent(inout), dimension(ldc, *) :: c
+   call dgemm(ta, tb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+end subroutine spral_c_dgemm
+
+subroutine spral_c_dpotrf(uplo, n, a, lda, info) bind(C)
+   use spral_lapack_iface, only : dpotrf
+   character(C_CHAR), intent(in) :: uplo
+   integer(C_INT), intent(in) :: n, lda
+   integer(C_INT), intent(out) :: info
+   real(C_DOUBLE), intent(inout), dimension(lda, *) :: a
+   call dpotrf(uplo, n, a, lda, info)
+end subroutine spral_c_dpotrf
+
+subroutine spral_c_dsytrf(uplo, n, a, lda, ipiv, work, lwork, info) bind(C)
+   use spral_lapack_iface, only : dsytrf
+   character(C_CHAR), intent(in) :: uplo
+   integer(C_INT), intent(in) :: n, lda, lwork
+   integer(C_INT), intent(out), dimension(n) :: ipiv
+   integer(C_INT), intent(out) :: info
+   real(C_DOUBLE), intent(inout), dimension(lda, *) :: a
+   real(C_DOUBLE), intent(out  ), dimension(*) :: work
+   call dsytrf(uplo, n, a, lda, ipiv, work, lwork, info)
+end subroutine spral_c_dsytrf
+
+subroutine spral_c_dtrsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, &
+                         ldb) bind(C)
+   use spral_blas_iface, only : dtrsm
+   character(C_CHAR), intent(in) :: side, uplo, transa, diag
+   integer(C_INT), intent(in) :: m, n, lda, ldb
+   real(C_DOUBLE), intent(in   ) :: alpha
+   real(C_DOUBLE), intent(in   ) :: a(lda, *)
+   real(C_DOUBLE), intent(inout) :: b(ldb, n)
+   call dtrsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+end subroutine spral_c_dtrsm
+
+subroutine spral_c_dsyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc) bind(C)
+   use spral_blas_iface, only : dsyrk
+   character(C_CHAR), intent(in) :: uplo, trans
+   integer(C_INT), intent(in) :: n, k, lda, ldc
+   real(C_DOUBLE), intent(in) :: alpha, beta
+   real(C_DOUBLE), intent(in   ), dimension(lda, *) :: a
+   real(C_DOUBLE), intent(inout), dimension(ldc, n) :: c
+   call dsyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+end subroutine spral_c_dsyrk
+
+subroutine spral_c_dtrsv(uplo, trans, diag, n, a, lda, x, incx) bind(C)
+   use spral_blas_iface, only : dtrsv
+   character(C_CHAR), intent(in) :: uplo, trans, diag
+   integer(C_INT), intent(in) :: n, lda, incx
+   real(C_DOUBLE), intent(in   ), dimension(lda, n) :: a
+   real(C_DOUBLE), intent(inout), dimension(*) :: x
+   call dtrsv(uplo, trans, diag, n, a, lda, x, incx)
+end subroutine spral_c_dtrsv
+
+subroutine spral_c_dgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy) &
+bind(C)
+   use spral_blas_iface, only : dgemv
+   character(C_CHAR), intent(in) :: trans
+   integer(C_INT), intent(in) :: m, n, lda, incx, incy
+   real(C_DOUBLE), intent(in) :: alpha, beta
+   real(C_DOUBLE), intent(in   ), dimension(lda, n) :: a
+   real(C_DOUBLE), intent(in   ), dimension(*) :: x
+   real(C_DOUBLE), intent(inout), dimension(*) :: y
+   call dgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+end subroutine spral_c_dgemv
+
 end module spral_ssids_cpu_iface

--- a/src/ssids/cpu/kernels/wrappers.cxx
+++ b/src/ssids/cpu/kernels/wrappers.cxx
@@ -8,13 +8,13 @@
 #include <stdexcept>
 
 extern "C" {
-   void dgemm_(char* transa, char* transb, int* m, int* n, int* k, double* alpha, const double* a, int* lda, const double* b, int* ldb, double *beta, double* c, int* ldc);
-   void dpotrf_(char *uplo, int *n, double *a, int *lda, int *info);
-   void dsytrf_(char *uplo, int *n, double *a, int *lda, int *ipiv, double *work, int *lwork, int *info);
-   void dtrsm_(char *side, char *uplo, char *transa, char *diag, int *m, int *n, const double *alpha, const double *a, int *lda, double *b, int *ldb);
-   void dsyrk_(char *uplo, char *trans, int *n, int *k, double *alpha, const double *a, int *lda, double *beta, double *c, int *ldc);
-   void dtrsv_(char *uplo, char *trans, char *diag, int *n, const double *a, int *lda, double *x, int *incx);
-   void dgemv_(char *trans, int *m, int *n, const double* alpha, const double* a, int *lda, const double* x, int* incx, const double* beta, double* y, int* incy);
+   void spral_c_dgemm(char* transa, char* transb, int* m, int* n, int* k, double* alpha, const double* a, int* lda, const double* b, int* ldb, double *beta, double* c, int* ldc);
+   void spral_c_dpotrf(char *uplo, int *n, double *a, int *lda, int *info);
+   void spral_c_dsytrf(char *uplo, int *n, double *a, int *lda, int *ipiv, double *work, int *lwork, int *info);
+   void spral_c_dtrsm(char *side, char *uplo, char *transa, char *diag, int *m, int *n, const double *alpha, const double *a, int *lda, double *b, int *ldb);
+   void spral_c_dsyrk(char *uplo, char *trans, int *n, int *k, double *alpha, const double *a, int *lda, double *beta, double *c, int *ldc);
+   void spral_c_dtrsv(char *uplo, char *trans, char *diag, int *n, const double *a, int *lda, double *x, int *incx);
+   void spral_c_dgemv(char *trans, int *m, int *n, const double* alpha, const double* a, int *lda, const double* x, int* incx, const double* beta, double* y, int* incy);
 }
 
 namespace spral { namespace ssids { namespace cpu {
@@ -24,14 +24,14 @@ template <>
 void host_gemm<double>(enum spral::ssids::cpu::operation transa, enum spral::ssids::cpu::operation transb, int m, int n, int k, double alpha, const double* a, int lda, const double* b, int ldb, double beta, double* c, int ldc) {
    char ftransa = (transa==spral::ssids::cpu::OP_N) ? 'N' : 'T';
    char ftransb = (transb==spral::ssids::cpu::OP_N) ? 'N' : 'T';
-   dgemm_(&ftransa, &ftransb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
+   spral_c_dgemm(&ftransa, &ftransb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
 }
 
 /* _GEMV */
 template <>
 void gemv<double>(enum spral::ssids::cpu::operation trans, int m, int n, double alpha, const double* a, int lda, const double* x, int incx, double beta, double* y, int incy) {
    char ftrans = (trans==spral::ssids::cpu::OP_N) ? 'N' : 'T';
-   dgemv_(&ftrans, &m, &n, &alpha, a, &lda, x, &incx, &beta, y, &incy);
+   spral_c_dgemv(&ftrans, &m, &n, &alpha, a, &lda, x, &incx, &beta, y, &incy);
 }
 
 /* _POTRF */
@@ -44,7 +44,7 @@ int lapack_potrf<double>(enum spral::ssids::cpu::fillmode uplo, int n, double* a
       default: throw std::runtime_error("Unknown fill mode");
    }
    int info;
-   dpotrf_(&fuplo, &n, a, &lda, &info);
+   spral_c_dpotrf(&fuplo, &n, a, &lda, &info);
    return info;
 }
 
@@ -58,7 +58,7 @@ int lapack_sytrf<double>(enum spral::ssids::cpu::fillmode uplo, int n, double* a
       default: throw std::runtime_error("Unknown fill mode");
    }
    int info;
-   dsytrf_(&fuplo, &n, a, &lda, ipiv, work, &lwork, &info);
+   spral_c_dsytrf(&fuplo, &n, a, &lda, ipiv, work, &lwork, &info);
    return info;
 }
 
@@ -67,7 +67,7 @@ template <>
 void host_syrk<double>(enum spral::ssids::cpu::fillmode uplo, enum spral::ssids::cpu::operation trans, int n, int k, double alpha, const double* a, int lda, double beta, double* c, int ldc) {
    char fuplo = (uplo==spral::ssids::cpu::FILL_MODE_LWR) ? 'L' : 'U';
    char ftrans = (trans==spral::ssids::cpu::OP_N) ? 'N' : 'T';
-   dsyrk_(&fuplo, &ftrans, &n, &k, &alpha, a, &lda, &beta, c, &ldc);
+   spral_c_dsyrk(&fuplo, &ftrans, &n, &k, &alpha, a, &lda, &beta, c, &ldc);
 }
 
 /* _TRSV */
@@ -76,7 +76,7 @@ void host_trsv<double>(enum spral::ssids::cpu::fillmode uplo, enum spral::ssids:
    char fuplo = (uplo==spral::ssids::cpu::FILL_MODE_LWR) ? 'L' : 'U';
    char ftrans = (trans==spral::ssids::cpu::OP_N) ? 'N' : 'T';
    char fdiag = (diag==spral::ssids::cpu::DIAG_UNIT) ? 'U' : 'N';
-   dtrsv_(&fuplo, &ftrans, &fdiag, &n, a, &lda, x, &incx);
+   spral_c_dtrsv(&fuplo, &ftrans, &fdiag, &n, a, &lda, x, &incx);
 }
 
 /* _TRSM */
@@ -86,7 +86,7 @@ void host_trsm<double>(enum spral::ssids::cpu::side side, enum spral::ssids::cpu
    char fuplo = (uplo==spral::ssids::cpu::FILL_MODE_LWR) ? 'L' : 'U';
    char ftransa = (transa==spral::ssids::cpu::OP_N) ? 'N' : 'T';
    char fdiag = (diag==spral::ssids::cpu::DIAG_UNIT) ? 'U' : 'N';
-   dtrsm_(&fside, &fuplo, &ftransa, &fdiag, &m, &n, &alpha, a, &lda, b, &ldb);
+   spral_c_dtrsm(&fside, &fuplo, &ftransa, &fdiag, &m, &n, &alpha, a, &lda, b, &ldb);
 }
 
 }}} /* namespaces spral::ssids::cpu */


### PR DESCRIPTION
Adds wrappers using `iso_c_binding` and `bind(c)` to allow standard conforming calls to BLAS/LAPACK functions from the SSIDS C++ code. See #4, and https://github.com/ralna/spral/issues/4#issuecomment-1209481973 for background, reasoning and alternatives.

On `gfortran`, without link time optimization, this adds another function call and a little bit of stack management (https://godbolt.org/z/ooKb4cboM). Without `bind(c)`, the stack management even reduces to just adding `1`s for the hidden string length arguments that exposed the broken non-standard function calls in #4 in the first place (https://godbolt.org/z/cjfK7Gjv4). I'm not quite sure why the compiler does not do the same with `bind(c)`, perhaps this is a missed optimization that can be leveraged in the future. This PR still proposes to go with `bind(c)` for standard compliance and to avoid to continue relying on implementation-defined behavior.

With these wrappers, the compiler flag workaround `-fno-optimize-sibling-calls` from #69 can be removed.