### PR TITLE
Fix type mismatch in call to zhegv

### DIFF
--- a/src/ssmfe/ssmfe.f90
+++ b/src/ssmfe/ssmfe.f90
@@ -2170,9 +2170,15 @@ contains
 
       k = ilaenv(1, 'ZHETRD', 'U', nep, -1, -1, -1)
       k = max(2*nep - 1, (k + 2)*nep) + 3*nep - 1    
+      allocate ( dwork(max(3*nep - 2, 1), 1), stat = inform%stat )
+      if ( inform%stat /= 0 ) inform%flag = OUT_OF_MEMORY
+      if ( inform%stat /= 0 ) rci%job = SSMFE_ABORT
+      if ( inform%stat /= 0 ) call ssmfe_errmsg( options, inform )
+      if ( inform%stat /= 0 ) return
       call zhegv &
         ( 1, 'V', 'U', nep, keep%V, nep, keep%V(1,1,2), nep, lambda, &
-          keep%U(3*nep, 1), k, keep%U, i )
+          keep%U(3*nep, 1), k, dwork, i )
+      deallocate ( dwork )
       call gemm &
         ( 'N', 'N', n, nep, nep, UNIT, keep%W, n, keep%V, nep, NIL, X, ldX )
 


### PR DESCRIPTION
https://github.com/ralna/spral/blob/7457139cf37f0ca3bdfeda6cf6e199a3c40300c6/src/ssmfe/ssmfe.f90#L2173-L2175
In this call to the LAPACK routine `zhegv`, the array `keep%U` of type complex is passed as second to last actual argument to the dummy argument `RWORK` which is an [array of type real](https://github.com/Reference-LAPACK/lapack/blob/dcba2e274af902f82ff554c47fc3178dbf9ac3e0/SRC/zhegv.f#L191). This type mismatch can be noticed

* by compiling with `-flto -Wlto-type-mismatch` which gives a warning,
* or by adding the interface for `zhegv` to the `spral_blas_iface` module and including it in the function where the call is made which gives a compilation error.

As the complex type should always be larger than the real type there should be more work memory than necessary, and because `zhegv` should not depend on any of the actual input values (with `RWORK` being `intent(out)`), this probably mostly happens to work. Still, to fix the type mismatch, this PR proposes to use the already available variable `dwork` with correct type as argument.

For other functions, all of `keep%U` seems to be needed as complex working memory, so from what I understand, it cannot be reduced in size for not needing to host the memory for the `RWORK` argument in said call anymore.
