### PR TITLE
Fix long integer on Windows

### DIFF
--- a/include/spral_matrix_util.h
+++ b/include/spral_matrix_util.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 #ifndef SPRAL_MATRIX_UTIL_H
 #define SPRAL_MATRIX_UTIL_H
 
@@ -24,11 +26,11 @@ enum spral_matrix_type {
    SPRAL_MATRIX_REAL_SKEW=6,        SPRAL_MATRIX_CPLX_SKEW=-6
 };
 
-void spral_half_to_full_i64d(int n, long *ptr, int *row, double *a, int base);
+void spral_half_to_full_i64d(int n, int64_t *ptr, int *row, double *a, int base);
 void spral_print_matrix(int lines, enum spral_matrix_type matrix_type, int m,
       int n, const int *ptr, const int *row, const double *val, int base);
 void spral_print_matrix_i64d(int lines, enum spral_matrix_type matrix_type,
-      int m, int n, const long *ptr, const int *row, const double *val,
+      int m, int n, const int64_t *ptr, const int *row, const double *val,
       int base);
 
 #ifdef __cplusplus

--- a/include/spral_random.h
+++ b/include/spral_random.h
@@ -15,7 +15,7 @@ double spral_random_real(int *state, bool positive);
 /* Generate a sample from discrete Unif(1,...,n) */
 int spral_random_integer(int *state, int n);
 /* Generate a sample from discrete Unif(1,...,n) */
-int64_t spral_random_int64_t(int *state, int64_t n);
+int64_t spral_random_long(int *state, int64_t n);
 /* Generate a sample with equal probability of true or false */
 bool spral_random_logical(int *state);
 

--- a/include/spral_random.h
+++ b/include/spral_random.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #define SPRAL_RANDOM_INITIAL_SEED 486502
 
@@ -14,7 +15,7 @@ double spral_random_real(int *state, bool positive);
 /* Generate a sample from discrete Unif(1,...,n) */
 int spral_random_integer(int *state, int n);
 /* Generate a sample from discrete Unif(1,...,n) */
-long spral_random_long(int *state, long n);
+int64_t spral_random_int64_t(int *state, int64_t n);
 /* Generate a sample with equal probability of true or false */
 bool spral_random_logical(int *state);
 

--- a/include/spral_random_matrix.h
+++ b/include/spral_random_matrix.h
@@ -15,9 +15,9 @@ extern "C" {
 /* Generate an m x n random matrix with nnz non-zero entries */
 int spral_random_matrix_generate(int *state, enum spral_matrix_type matrix_type,
       int m, int n, int nnz, int *ptr, int *row, double *val, int flags);
-/* Generate an m x n random matrix with nnz non-zero entries (nnz,ptr long) */
-int spral_random_matrix_generate_long(int *state,
-      enum spral_matrix_type matrix_type, int m, int n, long nnz, long *ptr,
+/* Generate an m x n random matrix with nnz non-zero entries (nnz,ptr int64_t) */
+int spral_random_matrix_generate_int64_t(int *state,
+      enum spral_matrix_type matrix_type, int m, int n, int64_t nnz, int64_t *ptr,
       int *row, double *val, int flags);
 
 #ifdef __cplusplus

--- a/include/spral_random_matrix.h
+++ b/include/spral_random_matrix.h
@@ -16,7 +16,7 @@ extern "C" {
 int spral_random_matrix_generate(int *state, enum spral_matrix_type matrix_type,
       int m, int n, int nnz, int *ptr, int *row, double *val, int flags);
 /* Generate an m x n random matrix with nnz non-zero entries (nnz,ptr int64_t) */
-int spral_random_matrix_generate_int64_t(int *state,
+int spral_random_matrix_generate_long(int *state,
       enum spral_matrix_type matrix_type, int m, int n, int64_t nnz, int64_t *ptr,
       int *row, double *val, int flags);
 

--- a/include/spral_rutherford_boeing.h
+++ b/include/spral_rutherford_boeing.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 struct spral_rb_read_options {
    int array_base;
    bool add_diagonal;
@@ -20,11 +22,11 @@ struct spral_rb_write_options {
 
 void spral_rb_default_read_options(struct spral_rb_read_options *options);
 void spral_rb_default_write_options(struct spral_rb_write_options *options);
-int spral_rb_peek(const char *filename, int *m, int *n, long *nelt, long *nvar,
-      long *nval, enum spral_matrix_type *matrix_type, char *type_code,
+int spral_rb_peek(const char *filename, int *m, int *n, int64_t *nelt, int64_t *nvar,
+      int64_t *nval, enum spral_matrix_type *matrix_type, char *type_code,
       char *title, char *identifier);
 int spral_rb_read(const char *filename, void **handle,
-      enum spral_matrix_type *matrix_type, int *m, int *n, long **ptr,
+      enum spral_matrix_type *matrix_type, int *m, int *n, int64_t **ptr,
       int **row, double **val, const struct spral_rb_read_options *options,
       char *title, char *identifier, int *state);
 int spral_rb_read_ptr32(const char *filename, void **handle,
@@ -32,7 +34,7 @@ int spral_rb_read_ptr32(const char *filename, void **handle,
       int **row, double **val, const struct spral_rb_read_options *options,
       char *title, char *identifier, int *state);
 int spral_rb_write(const char *filename, enum spral_matrix_type matrix_type,
-      int m, int n, const long *ptr, const int *row, const double * val,
+      int m, int n, const int64_t *ptr, const int *row, const double * val,
       const struct spral_rb_write_options *options, const char *title,
       const char *identifier);
 int spral_rb_write_ptr32(const char *filename,

--- a/include/spral_scaling.h
+++ b/include/spral_scaling.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /************************************
  * Derived types
@@ -76,7 +77,7 @@ void spral_scaling_auction_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
-void spral_scaling_auction_sym_long(int n, const long *ptr, const int *row,
+void spral_scaling_auction_sym_int64_t(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
@@ -85,7 +86,7 @@ void spral_scaling_equilib_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
-void spral_scaling_equilib_sym_long(int n, const long *ptr, const int *row,
+void spral_scaling_equilib_sym_int64_t(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
@@ -94,7 +95,7 @@ void spral_scaling_hungarian_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
-void spral_scaling_hungarian_sym_long(int n, const long *ptr, const int *row,
+void spral_scaling_hungarian_sym_int64_t(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
@@ -108,7 +109,7 @@ void spral_scaling_auction_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
-void spral_scaling_auction_unsym_long(int m, int n, const long *ptr,
+void spral_scaling_auction_unsym_int64_t(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
@@ -117,7 +118,7 @@ void spral_scaling_equilib_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
-void spral_scaling_equilib_unsym_long(int m, int n, const long *ptr,
+void spral_scaling_equilib_unsym_int64_t(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
@@ -126,7 +127,7 @@ void spral_scaling_hungarian_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
-void spral_scaling_hungarian_unsym_long(int m, int n, const long *ptr,
+void spral_scaling_hungarian_unsym_int64_t(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);

--- a/include/spral_scaling.h
+++ b/include/spral_scaling.h
@@ -77,7 +77,7 @@ void spral_scaling_auction_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
-void spral_scaling_auction_sym_int64_t(int n, const int64_t *ptr, const int *row,
+void spral_scaling_auction_sym_long(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
@@ -86,7 +86,7 @@ void spral_scaling_equilib_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
-void spral_scaling_equilib_sym_int64_t(int n, const int64_t *ptr, const int *row,
+void spral_scaling_equilib_sym_long(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
@@ -95,7 +95,7 @@ void spral_scaling_hungarian_sym(int n, const int *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
-void spral_scaling_hungarian_sym_int64_t(int n, const int64_t *ptr, const int *row,
+void spral_scaling_hungarian_sym_long(int n, const int64_t *ptr, const int *row,
       const double *val, double *scaling, int *match,
       const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
@@ -109,7 +109,7 @@ void spral_scaling_auction_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
-void spral_scaling_auction_unsym_int64_t(int m, int n, const int64_t *ptr,
+void spral_scaling_auction_unsym_long(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_auction_options *options,
       struct spral_scaling_auction_inform *inform);
@@ -118,7 +118,7 @@ void spral_scaling_equilib_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
-void spral_scaling_equilib_unsym_int64_t(int m, int n, const int64_t *ptr,
+void spral_scaling_equilib_unsym_long(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       const struct spral_scaling_equilib_options *options,
       struct spral_scaling_equilib_inform *inform);
@@ -127,7 +127,7 @@ void spral_scaling_hungarian_unsym(int m, int n, const int *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);
-void spral_scaling_hungarian_unsym_int64_t(int m, int n, const int64_t *ptr,
+void spral_scaling_hungarian_unsym_long(int m, int n, const int64_t *ptr,
       const int *row, const double *val, double *rscaling, double *cscaling,
       int *match, const struct spral_scaling_hungarian_options *options,
       struct spral_scaling_hungarian_inform *inform);

--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /************************************
  * Derived types
@@ -21,11 +22,11 @@ struct spral_ssids_options {
    int nemin;
    bool ignore_numa;
    bool use_gpu;
-   long min_gpu_work;
+   int64_t min_gpu_work;
    float max_load_inbalance;
    float gpu_perf_coeff;
    int scaling;
-   long small_subtree_threshold;
+   int64_t small_subtree_threshold;
    int cpu_block_size;
    bool action;
    int pivot_method;
@@ -43,8 +44,8 @@ struct spral_ssids_inform {
    int maxdepth;
    int maxfront;
    int num_delay;
-   long num_factor;
-   long num_flops;
+   int64_t num_factor;
+   int64_t num_flops;
    int num_neg;
    int num_sup;
    int num_two;
@@ -55,13 +56,13 @@ struct spral_ssids_inform {
 };
 
 /************************************
- * Basic subroutines 
+ * Basic subroutines
  ************************************/
 
 /* Initialize options to defaults */
 void spral_ssids_default_options(struct spral_ssids_options *options);
 /* Perform analysis phase for CSC data */
-void spral_ssids_analyse(bool check, int n, int *order, const long *ptr,
+void spral_ssids_analyse(bool check, int n, int *order, const int64_t *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
@@ -70,12 +71,12 @@ void spral_ssids_analyse_ptr32(bool check, int n, int *order, const int *ptr,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
 /* Perform analysis phase for coordinate data */
-void spral_ssids_analyse_coord(int n, int *order, long ne, const int *row,
+void spral_ssids_analyse_coord(int n, int *order, int64_t ne, const int *row,
       const int *col, const double *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
 /* Perform numerical factorization */
-void spral_ssids_factor(bool posdef, const long *ptr, const int *row,
+void spral_ssids_factor(bool posdef, const int64_t *ptr, const int *row,
       const double *val, double *scale, void *akeep, void **fkeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
@@ -97,7 +98,7 @@ int spral_ssids_free_fkeep(void **fkeep);
 int spral_ssids_free(void **akeep, void **fkeep);
 
 /************************************
- * Advanced subroutines 
+ * Advanced subroutines
  ************************************/
 
 /* Retrieve information on pivots (positive-definite case) */

--- a/interfaces/C/matrix_util.f90
+++ b/interfaces/C/matrix_util.f90
@@ -40,7 +40,7 @@ subroutine spral_print_matrix_i64d(lines, matrix_type, m, n, ptr, row, cval, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: base
@@ -68,7 +68,7 @@ subroutine spral_half_to_full_i64d(n, ptr, row, cval, base) bind(C)
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(inout) :: ptr
+  integer(C_INT64_T), dimension(*), intent(inout) :: ptr
   integer(C_INT),  dimension(*),intent(inout) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: base

--- a/interfaces/C/random.f90
+++ b/interfaces/C/random.f90
@@ -40,13 +40,13 @@ integer(C_INT) function spral_random_integer(cstate, n) bind(C)
    cstate = random_get_seed(fstate)
 end function spral_random_integer
 
-integer(C_LONG_LONG) function spral_random_long(cstate, n) bind(C)
+integer(C_INT64_T) function spral_random_long(cstate, n) bind(C)
    use iso_c_binding
    use spral_random
    implicit none
 
    integer(C_INT), intent(inout) :: cstate
-   integer(C_LONG_LONG), value :: n
+   integer(C_INT64_T), value :: n
 
    type(random_state) :: fstate
 

--- a/interfaces/C/random_matrix.f90
+++ b/interfaces/C/random_matrix.f90
@@ -69,8 +69,8 @@ integer(C_INT) function spral_random_matrix_generate_long(cstate, matrix_type, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), value :: nnz
-  integer(C_LONG_LONG), dimension(n+1), intent(out) :: ptr
+  integer(C_INT64_T), value :: nnz
+  integer(C_INT64_T), dimension(n+1), intent(out) :: ptr
   integer(C_INT), dimension(nnz), intent(out) :: row
   type(C_PTR), value :: cval
   integer(C_INT), value :: flags

--- a/interfaces/C/rutherford_boeing.f90
+++ b/interfaces/C/rutherford_boeing.f90
@@ -10,7 +10,7 @@ module spral_rutherford_boeing_ciface
 
   type handle_type
      integer(C_INT), dimension(:), allocatable :: ptr32
-     integer(C_LONG_LONG), dimension(:), allocatable :: ptr64
+     integer(C_INT64_T), dimension(:), allocatable :: ptr64
      integer(C_INT), dimension(:), allocatable :: row
      real(C_DOUBLE), dimension(:), allocatable :: val
   end type handle_type
@@ -163,7 +163,7 @@ integer(C_INT) function spral_rb_peek(filename, m, n, nelt, nvar, nval, &
   character(len=8) :: fidentifier
 
   integer(C_INT), pointer :: temp_int
-  integer(C_LONG_LONG), pointer :: temp_long
+  integer(C_INT64_T), pointer :: temp_long
 
   ! Convert filename to Fortran string
   call convert_string_c2f(filename, ffilename)
@@ -344,7 +344,7 @@ integer(C_INT) function spral_rb_write(filename, matrix_type, m, n, &
   integer(C_INT), value :: matrix_type
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(n+1), target, intent(in) :: ptr
+  integer(C_INT64_T), dimension(n+1), target, intent(in) :: ptr
   integer(C_INT), dimension(ptr(n+1)), target, intent(in) :: row
   type(C_PTR), value :: val
   type(spral_rb_write_options), intent(in) :: options
@@ -355,7 +355,7 @@ integer(C_INT) function spral_rb_write(filename, matrix_type, m, n, &
   character(len=:), allocatable :: ffilename, ftitle, fidentifier
   type(rb_write_options) :: foptions
   logical :: cindexed
-  integer(C_LONG_LONG), dimension(:), pointer :: fptr
+  integer(C_INT64_T), dimension(:), pointer :: fptr
   integer(C_INT), dimension(:), pointer :: frow
   real(C_DOUBLE), dimension(:), pointer :: fval
 

--- a/interfaces/C/scaling.f90
+++ b/interfaces/C/scaling.f90
@@ -229,7 +229,7 @@ subroutine spral_scaling_auction_sym_long(n, ptr, row, val, scaling, cmatch, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -325,7 +325,7 @@ subroutine spral_scaling_equilib_sym_long(n, ptr, row, val, scaling, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -421,7 +421,7 @@ subroutine spral_scaling_hungarian_sym_long(n, ptr, row, val, scaling, cmatch, &
   implicit none
 
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: scaling
@@ -544,7 +544,7 @@ subroutine spral_scaling_auction_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling
@@ -646,7 +646,7 @@ subroutine spral_scaling_equilib_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling
@@ -748,7 +748,7 @@ subroutine spral_scaling_hungarian_unsym_long(m, n, ptr, row, val, rscaling, &
 
   integer(C_INT), value :: m
   integer(C_INT), value :: n
-  integer(C_LONG_LONG), dimension(*), intent(in) :: ptr
+  integer(C_INT64_T), dimension(*), intent(in) :: ptr
   integer(C_INT), dimension(*), intent(in) :: row
   real(C_DOUBLE), dimension(*), intent(in) :: val
   real(C_DOUBLE), dimension(*), intent(out) :: rscaling

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -13,11 +13,11 @@ module spral_ssids_ciface
      integer(C_INT) :: nemin
      logical(C_BOOL) :: ignore_numa
      logical(C_BOOL) :: use_gpu
-     integer(C_LONG_LONG) :: min_gpu_work
+     integer(C_INT64_T) :: min_gpu_work
      real(C_FLOAT) :: max_load_inbalance
      real(C_FLOAT) :: gpu_perf_coeff
      integer(C_INT) :: scaling
-     integer(C_LONG_LONG) :: small_subtree_threshold
+     integer(C_INT64_T) :: small_subtree_threshold
      integer(C_INT) :: cpu_block_size
      logical(C_BOOL) :: action
      integer(C_INT) :: pivot_method
@@ -35,8 +35,8 @@ module spral_ssids_ciface
      integer(C_INT) :: maxdepth
      integer(C_INT) :: maxfront
      integer(C_INT) :: num_delay
-     integer(C_LONG_LONG) :: num_factor
-     integer(C_LONG_LONG) :: num_flops
+     integer(C_INT64_T) :: num_factor
+     integer(C_INT64_T) :: num_flops
      integer(C_INT) :: num_neg
      integer(C_INT) :: num_sup
      integer(C_INT) :: num_two
@@ -135,15 +135,15 @@ subroutine spral_ssids_analyse(ccheck, n, corder, cptr, crow, cval, cakeep, &
   logical(C_BOOL), value :: ccheck
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
-  integer(C_LONG_LONG), target, dimension(n+1) :: cptr
+  integer(C_INT64_T), target, dimension(n+1) :: cptr
   type(C_PTR), value :: cval
   type(C_PTR), intent(inout) :: cakeep
   type(spral_ssids_options), intent(in) :: coptions
   type(spral_ssids_inform), intent(out) :: cinform
   integer(C_INT), target, dimension(cptr(n+1)-coptions%array_base) :: crow
 
-  integer(C_LONG_LONG), dimension(:), pointer :: fptr
-  integer(C_LONG_LONG), dimension(:), allocatable, target :: fptr_alloc
+  integer(C_INT64_T), dimension(:), pointer :: fptr
+  integer(C_INT64_T), dimension(:), allocatable, target :: fptr_alloc
   integer(C_INT), dimension(:), pointer :: frow
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   logical :: fcheck
@@ -326,7 +326,7 @@ subroutine spral_ssids_analyse_coord(n, corder, ne, crow, ccol, cval, cakeep, &
 
   integer(C_INT), value :: n
   type(C_PTR), value :: corder
-  integer(C_LONG_LONG), value :: ne
+  integer(C_INT64_T), value :: ne
   integer(C_INT), target, dimension(ne) :: crow
   integer(C_INT), target, dimension(ne) :: ccol
   type(C_PTR), value :: cval
@@ -429,8 +429,8 @@ subroutine spral_ssids_factor(cposdef, cptr, crow, val, cscale, cakeep, cfkeep,&
   type(spral_ssids_inform), intent(out) :: cinform
   
   logical :: fposdef
-  integer(C_LONG_LONG), dimension(:), pointer :: fptr
-  integer(C_LONG_LONG), dimension(:), allocatable, target :: fptr_alloc
+  integer(C_INT64_T), dimension(:), pointer :: fptr
+  integer(C_INT64_T), dimension(:), allocatable, target :: fptr_alloc
   integer(C_INT), dimension(:), pointer :: frow
   integer(C_INT), dimension(:), allocatable, target :: frow_alloc
   real(C_DOUBLE), dimension(:), pointer :: fscale

--- a/src/ssids/cpu/cpu_iface.f90
+++ b/src/ssids/cpu/cpu_iface.f90
@@ -24,7 +24,7 @@ module spral_ssids_cpu_iface
       real(C_DOUBLE) :: small
       real(C_DOUBLE) :: u
       real(C_DOUBLE) :: multiplier
-      integer(C_LONG_LONG) :: small_subtree_threshold
+      integer(C_INT64_T) :: small_subtree_threshold
       integer(C_INT) :: cpu_block_size
       integer(C_INT) :: pivot_method
       integer(C_INT) :: failed_pivot_method

--- a/src/ssids/cpu/subtree.f90
+++ b/src/ssids/cpu/subtree.f90
@@ -51,10 +51,10 @@ module spral_ssids_cpu_subtree
        integer(C_INT), value :: en
        integer(C_INT), dimension(*), intent(in) :: sptr
        integer(C_INT), dimension(*), intent(in) :: sparent
-       integer(C_LONG_LONG), dimension(*), intent(in) :: rptr
+       integer(C_INT64_T), dimension(*), intent(in) :: rptr
        integer(C_INT), dimension(*), intent(in) :: rlist
-       integer(C_LONG_LONG), dimension(*), intent(in) :: nptr
-       integer(C_LONG_LONG), dimension(*), intent(in) :: nlist
+       integer(C_INT64_T), dimension(*), intent(in) :: nptr
+       integer(C_INT64_T), dimension(*), intent(in) :: nlist
        integer(C_INT), value :: ncontrib
        integer(C_INT), dimension(*), intent(in) :: contrib_idx
        type(cpu_factor_options), intent(in) :: options

--- a/src/ssids/gpu/datatypes.f90
+++ b/src/ssids/gpu/datatypes.f90
@@ -30,12 +30,12 @@ module spral_ssids_gpu_datatypes
 
 
    type, bind(C) :: load_nodes_type
-      integer(C_LONG_LONG) :: nnz   ! Number of entries to map
+      integer(C_INT64_T) :: nnz   ! Number of entries to map
       integer(C_INT) :: lda   ! Leading dimension of A
       integer(C_INT) :: ldl   ! Leading dimension of L
       type(C_PTR) :: lcol     ! Pointer to non-delay part of L
-      integer(C_LONG_LONG) :: offn  ! Offset into nlist
-      integer(C_LONG_LONG) :: offr ! Offset into rlist
+      integer(C_INT64_T) :: offn  ! Offset into nlist
+      integer(C_INT64_T) :: offr ! Offset into rlist
    end type load_nodes_type
 
    type, bind(C) :: assemble_cp_type
@@ -45,7 +45,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: cm
       integer(C_INT) :: cn
       integer(C_INT) :: ldc
-      integer(C_LONG_LONG) :: cvoffset
+      integer(C_INT64_T) :: cvoffset
       type(C_PTR) :: cv
       type(C_PTR) :: rlist_direct
       type(C_PTR) :: ind
@@ -61,7 +61,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: lds
       type(C_PTR) :: dval
       type(C_PTR) :: sval
-      integer(C_LONG_LONG) :: roffset
+      integer(C_INT64_T) :: roffset
    end type assemble_delay_type
 
    type, bind(C) :: assemble_blk_type
@@ -231,12 +231,12 @@ module spral_ssids_gpu_datatypes
       integer :: presolve = 0
       integer, dimension(:), allocatable :: lvlptr ! pointers into lvllist
       integer, dimension(:), allocatable :: lvllist ! list of nodes at level
-      integer(C_LONG_LONG), dimension(:), allocatable :: off_L ! offsets for each node
+      integer(C_INT64_T), dimension(:), allocatable :: off_L ! offsets for each node
       ! the following three are row offsets for independence from nrhs
       integer, dimension(:), allocatable :: off_lx ! node offsets for fwd solve
       integer, dimension(:), allocatable :: off_lc ! offsets for node contrib.
       integer, dimension(:), allocatable :: off_ln ! node offsets for bwd solve
-      integer(C_LONG_LONG) :: rd_size = 0
+      integer(C_INT64_T) :: rd_size = 0
       integer :: max_lx_size = 0
       integer :: max_lc_size = 0
       type(eltree_level), dimension(:), allocatable :: values_L(:) ! data
@@ -315,7 +315,7 @@ module spral_ssids_gpu_datatypes
       integer(C_INT) :: first
       type(C_PTR) :: lval
       type(C_PTR) :: ldval
-      integer(C_LONG_LONG) :: offc
+      integer(C_INT64_T) :: offc
       integer(C_INT) :: n
       integer(C_INT) :: k
       integer(C_INT) :: lda
@@ -342,7 +342,7 @@ module spral_ssids_gpu_datatypes
     integer(C_INT) :: ncols
     integer(C_INT) :: nrhs
     integer(C_INT) :: offb
-    integer(C_LONG_LONG) :: off_a
+    integer(C_INT64_T) :: off_a
     integer(C_INT) :: off_b
     integer(C_INT) :: off_u
     integer(C_INT) :: off_v

--- a/src/ssids/gpu/interfaces.f90
+++ b/src/ssids/gpu/interfaces.f90
@@ -74,7 +74,7 @@ module spral_ssids_gpu_interfaces
          implicit none
          type(C_PTR), value :: stream
          integer(C_INT), intent(in), value :: nb
-         integer(C_LONG_LONG), intent(in), value :: n
+         integer(C_INT64_T), intent(in), value :: n
          type(C_PTR), value :: array
          type(C_PTR), value :: buff
          type(C_PTR), value :: maxabs

--- a/src/ssids/gpu/subtree.f90
+++ b/src/ssids/gpu/subtree.f90
@@ -242,7 +242,7 @@ contains
       rlist_direct, gpu_nlist, gpu_rlist, gpu_rlist_direct, cuda_error)
    implicit none
    integer(long), intent(in) :: lnlist
-   integer(C_LONG_LONG), dimension(lnlist), target, intent(in) :: nlist
+   integer(C_INT64_T), dimension(lnlist), target, intent(in) :: nlist
    integer(long), intent(in) :: lrlist
    integer(C_INT), dimension(lrlist), target, intent(in) :: rlist
    integer(C_INT), dimension(lrlist), target, intent(in) :: rlist_direct

--- a/src/timer.f90
+++ b/src/timer.f90
@@ -7,7 +7,7 @@ module spral_timespec
 
    type, bind(C) :: timespec
       integer(C_INT) :: tv_sec
-      integer(C_LONG_LONG) :: tv_nsec
+      integer(C_INT64_T) :: tv_nsec
    end type timespec
 end module spral_timespec
 


### PR DESCRIPTION
Switch from using C `long` to C `int64_t` so that long integers on Windows are always 64bit.

Long integers on the Fortran side are always 64bit as they are specified with `selected_int_kind(18)`