### PR TITLE
Remove more default(none) to allow clang compilation

### DIFF
--- a/src/ssids/cpu/kernels/assemble.hxx
+++ b/src/ssids/cpu/kernels/assemble.hxx
@@ -206,7 +206,7 @@ void assemble_pre(
       // Multiple blocks
       #pragma omp taskgroup
       for(int iblk=0; iblk<snode.num_a; iblk+=add_a_blk_sz) {
-         #pragma omp task default(none) \
+         #pragma omp task \
             firstprivate(iblk) \
             shared(snode, node, aval, scaling, ldl)
          add_a_block(iblk, std::min(iblk+add_a_blk_sz,snode.num_a), node, aval, scaling);
@@ -278,7 +278,7 @@ void assemble_pre(
             // Multiple blocks
             #pragma omp taskgroup
             for(int iblk=0; iblk<cm; iblk+=block_size) {
-               #pragma omp task default(none) \
+               #pragma omp task \
                   firstprivate(iblk) \
                   shared(map, child, snode, node, csnode, cm, nrow, work)
                {
@@ -386,7 +386,7 @@ void assemble_post(
          } else {
             #pragma omp taskgroup
             for(int iblk=0; iblk<cm; iblk+=block_size) {
-               #pragma omp task default(none) \
+               #pragma omp task \
                   firstprivate(iblk) \
                   shared(map, child, node, cm, work)
                {


### PR DESCRIPTION
In gcc9+/clang, const vars are required to be explicilty specified in shared when default(none) is defined. A backwards compatible fix is to remove this.