### PR TITLE
Remove std::align macro as it is in C++11

### DIFF
--- a/src/compat.hxx
+++ b/src/compat.hxx
@@ -13,14 +13,6 @@
 
 #include "config.h"
 
-#ifndef HAVE_STD_ALIGN
-// Older versions of g++ (and intel that relies on equivalent -lstdc++) don't
-// define std::align, so we do it ourselves.
-namespace std {
-void* align(std::size_t alignment, std::size_t size, void*& ptr, std::size_t& space) noexcept;
-} /* namespace std */
-#endif /* HAVE_STD_ALIGN */
-
 #ifndef _OPENMP
 inline int omp_get_thread_num(void) { return 0; }
 inline int omp_get_num_threads(void) { return 1; }


### PR DESCRIPTION
`std::align` has been present since C++11 therefore I suggest we simply drop the macro from `compat.hxx`, all modern compilers fully implement the C++11 standard now (as it dates back to 2011).