### PR TITLE
Fix missed longs in C++ and CUDA kernels

### DIFF
--- a/src/ssids/cpu/SmallLeafNumericSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafNumericSubtree.hxx
@@ -34,7 +34,7 @@ class SmallLeafNumericSubtree<true, T, FactorAllocator, PoolAllocator> {
    typedef typename std::allocator_traits<FactorAllocator>::template rebind_traits<int> FAIntTraits;
    typedef std::allocator_traits<PoolAllocator> PATraits;
 public:
-   SmallLeafNumericSubtree(SmallLeafSymbolicSubtree const& symb, std::vector<NumericNode<T,PoolAllocator>>& old_nodes, T const* aval, T const* scaling, FactorAllocator& factor_alloc, PoolAllocator& pool_alloc, std::vector<Workspace>& work_vec, struct cpu_factor_options const& options, ThreadStats& stats) 
+   SmallLeafNumericSubtree(SmallLeafSymbolicSubtree const& symb, std::vector<NumericNode<T,PoolAllocator>>& old_nodes, T const* aval, T const* scaling, FactorAllocator& factor_alloc, PoolAllocator& pool_alloc, std::vector<Workspace>& work_vec, struct cpu_factor_options const& options, ThreadStats& stats)
       : old_nodes_(old_nodes), symb_(symb), lcol_(FADoubleTraits::allocate(factor_alloc, symb.nfactor_))
    {
       Workspace& work = work_vec[omp_get_thread_num()];
@@ -78,8 +78,8 @@ void add_a(
    if(scaling) {
       /* Scaling to apply */
       for(int i=0; i<snode.num_a; i++) {
-         long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-         long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+         int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+         int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
          int c = dest / snode.nrow;
          int r = dest % snode.nrow;
          T rscale = scaling[ snode.rlist[r]-1 ];
@@ -90,8 +90,8 @@ void add_a(
    } else {
       /* No scaling to apply */
       for(int i=0; i<snode.num_a; i++) {
-         long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-         long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+         int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+         int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
          int c = dest / snode.nrow;
          int r = dest % snode.nrow;
          size_t k = c*ldl + r;
@@ -118,7 +118,7 @@ void assemble(
    int ncol = snode.ncol;
 
    /* Get space for contribution block + zero it */
-   long contrib_dimn = snode.nrow - snode.ncol;
+   int64_t contrib_dimn = snode.nrow - snode.ncol;
    node->contrib = (contrib_dimn > 0) ? PATraits::allocate(pool_alloc, contrib_dimn*contrib_dimn) : nullptr;
    if(node->contrib)
       memset(node->contrib, 0, contrib_dimn*contrib_dimn*sizeof(T));
@@ -186,7 +186,7 @@ class SmallLeafNumericSubtree<false, T, FactorAllocator, PoolAllocator> {
    typedef typename std::allocator_traits<FactorAllocator>::template rebind_traits<int> FAIntTraits;
    typedef std::allocator_traits<PoolAllocator> PATraits;
 public:
-   SmallLeafNumericSubtree(SmallLeafSymbolicSubtree const& symb, std::vector<NumericNode<T,PoolAllocator>>& old_nodes, T const* aval, T const* scaling, FactorAllocator& factor_alloc, PoolAllocator& pool_alloc, std::vector<Workspace>& work_vec, struct cpu_factor_options const& options, ThreadStats& stats) 
+   SmallLeafNumericSubtree(SmallLeafSymbolicSubtree const& symb, std::vector<NumericNode<T,PoolAllocator>>& old_nodes, T const* aval, T const* scaling, FactorAllocator& factor_alloc, PoolAllocator& pool_alloc, std::vector<Workspace>& work_vec, struct cpu_factor_options const& options, ThreadStats& stats)
    : old_nodes_(old_nodes), symb_(symb)
    {
       Workspace& work = work_vec[omp_get_thread_num()];
@@ -244,7 +244,7 @@ private:
       memset(node.lcol, 0, len*sizeof(T));
 
       /* Get space for contribution block + (explicitly do not zero it!) */
-      long contrib_dimn = snode.nrow - snode.ncol;
+      int64_t contrib_dimn = snode.nrow - snode.ncol;
       node.contrib = (contrib_dimn > 0) ? PATraits::allocate(pool_alloc, contrib_dimn*contrib_dimn) : nullptr;
 
       /* Alloc + set perm for expected eliminations at this node (delays are set
@@ -257,11 +257,11 @@ private:
       if(scaling) {
          /* Scaling to apply */
          for(int i=0; i<snode.num_a; i++) {
-            long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-            long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+            int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+            int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
             int c = dest / snode.nrow;
             int r = dest % snode.nrow;
-            long k = c*ldl + r;
+            int64_t k = c*ldl + r;
             if(r >= snode.ncol) k += node.ndelay_in;
             T rscale = scaling[ snode.rlist[r]-1 ];
             T cscale = scaling[ snode.rlist[c]-1 ];
@@ -270,11 +270,11 @@ private:
       } else {
          /* No scaling to apply */
          for(int i=0; i<snode.num_a; i++) {
-            long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-            long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+            int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+            int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
             int c = dest / snode.nrow;
             int r = dest % snode.nrow;
-            long k = c*ldl + r;
+            int64_t k = c*ldl + r;
             if(r >= snode.ncol) k += node.ndelay_in;
             node.lcol[k] = aval[src];
          }
@@ -384,7 +384,7 @@ private:
          node->free_contrib();
       } else if(node->nelim==0) {
          // FIXME: If we fix the above, we don't need this explict zeroing
-         long contrib_size = m-n;
+         int64_t contrib_size = m-n;
          memset(node->contrib, 0, contrib_size*contrib_size*sizeof(T));
       }
    }

--- a/src/ssids/cpu/SmallLeafNumericSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafNumericSubtree.hxx
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "ssids/cpu/cpu_iface.hxx"

--- a/src/ssids/cpu/SmallLeafSymbolicSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafSymbolicSubtree.hxx
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "ssids/cpu/cpu_iface.hxx"

--- a/src/ssids/cpu/SmallLeafSymbolicSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafSymbolicSubtree.hxx
@@ -36,7 +36,7 @@ private:
    };
 
 public:
-   /** 
+   /**
     * \brief Constructor
     *
     * Perform work in the analyse phase of the solver. Set up data structures
@@ -71,7 +71,7 @@ public:
     *        nlist[2*i+1] of the relevant supernode (as per nptr) of \f$ L \f$.
     * \param symb Underlying SymbolicSubtree for containing parttree.
     */
-   SmallLeafSymbolicSubtree(int sa, int en, int part_offset, int const* sptr, int const* sparent, long const* rptr, int const* rlist, long const* nptr, long const* nlist, SymbolicSubtree const& symb)
+   SmallLeafSymbolicSubtree(int sa, int en, int part_offset, int const* sptr, int const* sparent, int64_t const* rptr, int const* rlist, int64_t const* nptr, int64_t const* nlist, SymbolicSubtree const& symb)
    : sa_(sa), en_(en), nnodes_(en-sa+1), parent_(sparent[part_offset+en]-1-part_offset),
      nodes_(nnodes_),
      rlist_(new int[rptr[part_offset+en+1]-rptr[part_offset+sa]], std::default_delete<int[]>()),
@@ -119,10 +119,10 @@ protected:
    int parent_; //< Parent of subtree in parttree.
    std::vector<Node> nodes_; //< Nodes of this subtree.
    std::shared_ptr<int> rlist_; //< Row entries of this subtree.
-   long const* nptr_; //< Node mapping into nlist_.
-   long const* nlist_; //< Mapping from \f$ A \f$ to \f$ L \f$.
+   int64_t const* nptr_; //< Node mapping into nlist_.
+   int64_t const* nlist_; //< Mapping from \f$ A \f$ to \f$ L \f$.
    SymbolicSubtree const& symb_; //< Underlying parttree
-   
+
    template <bool posdef, typename T, typename FactorAllocator,
              typename PoolAllocator>
    friend class SmallLeafNumericSubtree;

--- a/src/ssids/cpu/SymbolicNode.hxx
+++ b/src/ssids/cpu/SymbolicNode.hxx
@@ -19,7 +19,7 @@ struct SymbolicNode {
    SymbolicNode* next_child; //< Pointer to second child in linked list
    int const* rlist; //< Pointer to row lists
    int num_a; //< Number of entries mapped from A to L
-   long const* amap; //< Pointer to map from A to L locations
+   int64_t const* amap; //< Pointer to map from A to L locations
    int parent; //< index of parent node
    std::vector<int> contrib; //< index of expected contribution(s)
 };

--- a/src/ssids/cpu/SymbolicNode.hxx
+++ b/src/ssids/cpu/SymbolicNode.hxx
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 namespace spral { namespace ssids { namespace cpu {

--- a/src/ssids/cpu/SymbolicSubtree.cxx
+++ b/src/ssids/cpu/SymbolicSubtree.cxx
@@ -10,7 +10,7 @@ using namespace spral::ssids::cpu;
 extern "C"
 void* spral_ssids_cpu_create_symbolic_subtree(
       int n, int sa, int en, int const* sptr, int const* sparent,
-      long const* rptr, int const* rlist, long const* nptr, long const* nlist,
+      int64_t const* rptr, int const* rlist, int64_t const* nptr, int64_t const* nlist,
       int ncontrib, int const* contrib_idx,
       struct cpu_factor_options const* options) {
    return (void*) new SymbolicSubtree(

--- a/src/ssids/cpu/SymbolicSubtree.hxx
+++ b/src/ssids/cpu/SymbolicSubtree.hxx
@@ -16,7 +16,7 @@ namespace spral { namespace ssids { namespace cpu {
 /** Symbolic factorization of a subtree to be factored on the CPU */
 class SymbolicSubtree {
 public:
-   SymbolicSubtree(int n, int sa, int en, int const* sptr, int const* sparent, long const* rptr, int const* rlist, long const* nptr, long const* nlist, int ncontrib, int const* contrib_idx, struct cpu_factor_options const& options)
+   SymbolicSubtree(int n, int sa, int en, int const* sptr, int const* sparent, int64_t const* rptr, int const* rlist, int64_t const* nptr, int64_t const* nlist, int ncontrib, int const* contrib_idx, struct cpu_factor_options const& options)
    : n(n), nnodes_(en-sa), nodes_(nnodes_+1)
    {
       // Adjust sa to C indexing (en is not used except in nnodes_ init above)
@@ -55,7 +55,7 @@ public:
          nfactor_ += static_cast<size_t>(nodes_[ni].nrow)*nodes_[ni].ncol;
       /* Find small leaf subtrees */
       // Count flops below each node
-      std::vector<long> flops(nnodes_+1, 0);
+      std::vector<int64_t> flops(nnodes_+1, 0);
       for(int ni=0; ni<nnodes_; ++ni) {
          for(int k=0; k<nodes_[ni].ncol; ++k)
             flops[ni] += (nodes_[ni].nrow - k)*(nodes_[ni].nrow - k);

--- a/src/ssids/cpu/SymbolicSubtree.hxx
+++ b/src/ssids/cpu/SymbolicSubtree.hxx
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "ssids/cpu/SmallLeafSymbolicSubtree.hxx"

--- a/src/ssids/cpu/cpu_iface.hxx
+++ b/src/ssids/cpu/cpu_iface.hxx
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace spral { namespace ssids { namespace cpu {
 

--- a/src/ssids/cpu/cpu_iface.hxx
+++ b/src/ssids/cpu/cpu_iface.hxx
@@ -26,7 +26,7 @@ struct cpu_factor_options {
    double small;
    double u;
    double multiplier;
-   long small_subtree_threshold;
+   int64_t small_subtree_threshold;
    int cpu_block_size;
    PivotMethod pivot_method;
    FailedPivotMethod failed_pivot_method;

--- a/src/ssids/cpu/factor.hxx
+++ b/src/ssids/cpu/factor.hxx
@@ -8,6 +8,7 @@
 /* Standard headers */
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 

--- a/src/ssids/cpu/factor.hxx
+++ b/src/ssids/cpu/factor.hxx
@@ -125,7 +125,7 @@ void factor_node_indef(
       node.free_contrib();
    } else if(node.nelim==0) {
       // FIXME: If we fix the above, we don't need this explict zeroing
-      long contrib_size = m-n;
+      int64_t contrib_size = m-n;
       memset(node.contrib, 0, contrib_size*contrib_size*sizeof(T));
    }
 }

--- a/src/ssids/cpu/kernels/assemble.hxx
+++ b/src/ssids/cpu/kernels/assemble.hxx
@@ -54,11 +54,11 @@ void add_a_block(int from, int to, NumericNode& node, T const* aval,
    if(scaling) {
       /* Scaling to apply */
       for(int i=from; i<to; ++i) {
-         long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-         long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+         int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+         int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
          int c = dest / snode.nrow;
          int r = dest % snode.nrow;
-         long k = c*ldl + r;
+         int64_t k = c*ldl + r;
          if(r >= snode.ncol) k += node.ndelay_in;
          T rscale = scaling[ snode.rlist[r]-1 ];
          T cscale = scaling[ snode.rlist[c]-1 ];
@@ -67,11 +67,11 @@ void add_a_block(int from, int to, NumericNode& node, T const* aval,
    } else {
       /* No scaling to apply */
       for(int i=from; i<to; ++i) {
-         long src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
-         long dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
+         int64_t src  = snode.amap[2*i+0] - 1; // amap contains 1-based values
+         int64_t dest = snode.amap[2*i+1] - 1; // amap contains 1-based values
          int c = dest / snode.nrow;
          int r = dest % snode.nrow;
-         long k = c*ldl + r;
+         int64_t k = c*ldl + r;
          if(r >= snode.ncol) k += node.ndelay_in;
          node.lcol[k] = aval[src];
       }

--- a/src/ssids/cpu/kernels/assemble.hxx
+++ b/src/ssids/cpu/kernels/assemble.hxx
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include<cstdint>
 #include<cstring>
 #include<memory>
 #include<vector>

--- a/src/ssids/cpu/kernels/cholesky.cxx
+++ b/src/ssids/cpu/kernels/cholesky.cxx
@@ -6,6 +6,7 @@
 #include "ssids/cpu/kernels/cholesky.hxx"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdio> // FIXME: remove as only used for debug
 
 #include "ssids/profile.hxx"

--- a/src/ssids/cpu/kernels/cholesky.cxx
+++ b/src/ssids/cpu/kernels/cholesky.cxx
@@ -32,7 +32,7 @@ namespace spral { namespace ssids { namespace cpu {
 void cholesky_factor(int m, int n, double* a, int lda, double beta, double* upd, int ldupd, int blksz, int *info) {
    if(n < blksz) {
       // Adjust so blocks have blksz**2 entries
-      blksz = int((long(blksz)*blksz) / n);
+      blksz = int((int64_t(blksz)*blksz) / n);
    }
 
    #pragma omp atomic write

--- a/src/ssids/cpu/kernels/ldlt_app.cxx
+++ b/src/ssids/cpu/kernels/ldlt_app.cxx
@@ -9,6 +9,7 @@
 #include <climits>
 #include <cmath>
 #include <cstdio>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <limits>

--- a/src/ssids/cpu/kernels/ldlt_app.cxx
+++ b/src/ssids/cpu/kernels/ldlt_app.cxx
@@ -345,7 +345,7 @@ void apply_pivot(int m, int n, int from, const T *diag, const T *d, const T smal
                // Handle zero pivots carefully
                for(int j=0; j<m; j++) {
                   T v = aval[i*lda+j];
-                  aval[i*lda+j] = 
+                  aval[i*lda+j] =
                      (fabs(v)<small) ? 0.0
                                      : std::numeric_limits<T>::infinity()*v;
                   // NB: *v above handles NaNs correctly
@@ -383,7 +383,7 @@ void apply_pivot(int m, int n, int from, const T *diag, const T *d, const T smal
                // Handle zero pivots carefully
                for(int j=from; j<n; j++) {
                   T v = aval[j*lda+i];
-                  aval[j*lda+i] = 
+                  aval[j*lda+i] =
                      (fabs(v)<small) ? 0.0 // *v handles NaNs
                                      : std::numeric_limits<T>::infinity()*v;
                   // NB: *v above handles NaNs correctly
@@ -1360,7 +1360,7 @@ private:
 #endif /* _OPENMP */
             }
          } } /* task/abort */
-         
+
          // Loop over off-diagonal blocks applying pivot
          for(int jblk = 0; jblk < blk; jblk++) {
             #pragma omp task                                          \
@@ -1617,7 +1617,7 @@ private:
                // Init threshold check (non locking => task dependencies)
                cdata[blk].init_passed(nelim);
             }
-            
+
             // Loop over off-diagonal blocks applying pivot
             for(int jblk=0; jblk<blk; jblk++) {
                if(debug) printf("ApplyT(%d,%d)\n", blk, jblk);
@@ -1695,7 +1695,7 @@ private:
                T *upd2 = &upd[uoffset*(ldupd+1)];
                for(int jblk=nblk; jblk<mblk; ++jblk)
                for(int iblk=jblk; iblk<mblk; ++iblk) {
-                  T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd + 
+                  T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd +
                                     (iblk-nblk)*block_size];
                   {
                      if(debug) printf("FormContrib(%d,%d,%d)\n", iblk, jblk, blk);
@@ -1818,7 +1818,7 @@ private:
 #endif /* _OPENMP */
             }
          } } /* task/abort */
-         
+
          // Loop over off-diagonal blocks applying pivot
          for (int jblk = 0; jblk < blk; jblk++) {
             #pragma omp task                                              \
@@ -2032,7 +2032,7 @@ private:
          } catch(SingularError const&) {
             return Flag::ERROR_SINGULAR;
          }
-         
+
          // Loop over off-diagonal blocks applying pivot
          for(int jblk=0; jblk<blk; jblk++) {
             if(debug) printf("ApplyT(%d,%d)\n", blk, jblk);
@@ -2090,7 +2090,7 @@ private:
             T *upd2 = &upd[uoffset*(ldupd+1)];
             for(int jblk=nblk; jblk<mblk; ++jblk)
             for(int iblk=jblk; iblk<mblk; ++iblk) {
-            T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd + 
+            T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd +
                               (iblk-nblk)*block_size];
                if(debug) printf("FormContrib(%d,%d,%d)\n", iblk, jblk, blk);
                int thread_num = omp_get_thread_num();
@@ -2205,7 +2205,7 @@ private:
          for(int iblk=jblk; iblk<mblk; ++iblk) {
             int progress = up_to_date[jblk*mblk+iblk];
             if(progress >= nelim_blk) progress = -1; // needs complete reset
-            T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd + 
+            T* upd_ij = &upd2[(jblk-nblk)*block_size*ldupd +
                               (iblk-nblk)*block_size];
             for(int kblk=progress+1; kblk<nelim_blk; ++kblk) {
                // NB: no need for isrc or jsrc dep as must be good already
@@ -2457,7 +2457,7 @@ public:
                      );
             jinsert += cdata[jblk].nelim;
          }
-         
+
          // Store failed entries back to correct locations
          // Diagonal part
          for(int j=0; j<n; ++j)
@@ -2509,7 +2509,7 @@ int ldlt_app_factor(int m, int n, int* perm, T* a, int lda, T* d, T beta, T* upd
    //        a lot more update tasks instead?
    int outer_block_size = options.cpu_block_size;
    /*if(n < outer_block_size) {
-       outer_block_size = int((long(outer_block_size)*outer_block_size) / n);
+       outer_block_size = int((int64_t(outer_block_size)*outer_block_size) / n);
    }*/
 
 #ifdef PROFILE

--- a/src/ssids/gpu/kernels/assemble.cu
+++ b/src/ssids/gpu/kernels/assemble.cu
@@ -1,7 +1,9 @@
 #ifdef __cplusplus
 #include <cmath>
+#include <cstdint>
 #else
 #include <math.h>
+#include <stdint.h>
 #endif
 
 #include <cuda_runtime.h>

--- a/src/ssids/gpu/kernels/syrk.cu
+++ b/src/ssids/gpu/kernels/syrk.cu
@@ -27,11 +27,11 @@ namespace /* anon */ {
 
 
 template< int WIDTH >
-inline __device__ void 
-loadDevToSmem_generic( volatile double *const __restrict__ as, volatile double *const __restrict__ bs, 
-               const double* __restrict__ a, const double* __restrict__ b, 
-               int bx, int by, int offa, int lda, int ldb, 
-               int n, int i, int k) 
+inline __device__ void
+loadDevToSmem_generic( volatile double *const __restrict__ as, volatile double *const __restrict__ bs,
+               const double* __restrict__ a, const double* __restrict__ b,
+               int bx, int by, int offa, int lda, int ldb,
+               int n, int i, int k)
 {
   switch (WIDTH) {
     case 4:
@@ -151,7 +151,7 @@ case 2:
       }
     }
     break;
-    
+
     default:
       printf("Invalid SYRK width\n");
   }
@@ -161,14 +161,14 @@ struct multisyrk_type {
   int first;
   double *lval;
   double *ldval;
-  long offc;
+  int64_t offc;
   int n;
   int k;
   int lda;
   int ldb;
 };
 
-// multisyrk kernels below compute the low trangular part of a*b^T 
+// multisyrk kernels below compute the low trangular part of a*b^T
 // (stored columnwise) using 8x8 cuda blocks
 
 template< typename ELEMENT_TYPE >
@@ -206,7 +206,7 @@ cu_multisyrk_lc_r4x4(
   __shared__ volatile ELEMENT_TYPE as2[32 * SYRK_WIDTH], bs2[32 * SYRK_WIDTH];
 #endif
 #endif
-  
+
   msdata += blockIdx.x;
   int first = msdata->first;
   const ELEMENT_TYPE * __restrict__ a = msdata->lval;
@@ -244,17 +244,17 @@ cu_multisyrk_lc_r4x4(
   for ( int i = 0; i < 16; i++ )
     s[i] = 0.0;
 #endif
-    
-    
+
+
 #if (SYRK_WIDTH <= 2 && DOUBLE_BUFFERED)
-  loadDevToSmem_generic<SYRK_WIDTH>( (volatile double*)as, bs, a, b, bx, by, 0, lda, ldb, n, 0, k );    
+  loadDevToSmem_generic<SYRK_WIDTH>( (volatile double*)as, bs, a, b, bx, by, 0, lda, ldb, n, 0, k );
 #endif
-    
+
   for ( int i = 0; i < k; i += SYRK_WIDTH ) {
 
 
 
-    // We want to get these in flight as early as possible so we can hide their 
+    // We want to get these in flight as early as possible so we can hide their
     // latency. We would also want to get the other set of loads in flight in a
     // similar manner, but this degrades performance (and makes the code more
     // complicated). I suspect it adds register pressure as it was quite a
@@ -276,7 +276,7 @@ cu_multisyrk_lc_r4x4(
       for ( int iy = 0; iy < 4; iy++ ) {
 #if (USE_DOUBLE2)
         s[iy*2    ].x += as[threadIdx.x + ix * 16    ].x*bs[threadIdx.y + 8*iy + ix * 32];
-        s[iy*2    ].y += as[threadIdx.x + ix * 16    ].y*bs[threadIdx.y + 8*iy + ix * 32]; 
+        s[iy*2    ].y += as[threadIdx.x + ix * 16    ].y*bs[threadIdx.y + 8*iy + ix * 32];
         s[iy*2 + 1].x += as[threadIdx.x + ix * 16 + 8].x*bs[threadIdx.y + 8*iy + ix * 32];
         s[iy*2 + 1].y += as[threadIdx.x + ix * 16 + 8].y*bs[threadIdx.y + 8*iy + ix * 32];
 #else
@@ -300,7 +300,7 @@ cu_multisyrk_lc_r4x4(
        loadDevToSmem_generic<SYRK_WIDTH>( (volatile double*)as, bs, a, b, bx, by, 0, lda, ldb, n, i + SYRK_WIDTH, k );
 #endif
     }
-    
+
     #pragma unroll
     for ( int ix = 0; ix < SYRK_WIDTH; ix++) {
       for ( int iy = 0; iy < 4; iy++ ) {
@@ -317,8 +317,8 @@ cu_multisyrk_lc_r4x4(
 #endif
       }
     }
-    
-#endif // DOUBLE_BUFFERED 
+
+#endif // DOUBLE_BUFFERED
     __syncthreads();
 
   }
@@ -331,21 +331,21 @@ cu_multisyrk_lc_r4x4(
       if ( x < n && y < n && y <= x ) {
         c[offc + x + y*n] = -s[ix + iy*2].x;
       }
-      
+
       x += 1;
       if ( x < n && y < n && y <= x ) {
         c[offc + x + y*n] = -s[ix + iy*2].y;
       }
     }
   }
-#else  
+#else
   int xMaxBase = (3 + bx*4)*8;
   int yMaxBase = (3 + by*4)*8;
 
   int XNPass = xMaxBase + 8 < n;
   int YNPass = yMaxBase + 8 < n;
   int YXPass = yMaxBase + 8 <= xMaxBase;
-  
+
   // This is only a small improvement (~1%)
   if (XNPass && YNPass && YXPass) {
     for ( int iy = 0; iy < 4; iy++ ) {
@@ -399,7 +399,7 @@ cu_multisyrk_r4x4(
     int* stat,
     multielm_data* mdata,
     int off,
-    struct multinode_fact_type *ndatat 
+    struct multinode_fact_type *ndatat
 ){
   int bx, by;
   int n, m, k;
@@ -421,7 +421,7 @@ cu_multisyrk_r4x4(
 #if (DOUBLE_BUFFERED)
   __shared__ volatile ELEMENT_TYPE as2[32 * SYRK_WIDTH];
   __shared__ volatile ELEMENT_TYPE bs2[32 * SYRK_WIDTH];
-#endif  
+#endif
 
   mdata += blockIdx.x;
   bx = mdata->node;
@@ -466,7 +466,7 @@ cu_multisyrk_r4x4(
 #if (DOUBLE_BUFFERED)
   loadDevToSmem_generic<SYRK_WIDTH>( (volatile double*)as, bs, a, b, bx, by, offa, lda, ldb, n, 0, k );
 #endif
-  
+
   for ( int i = 0; i < k; i += SYRK_WIDTH ) {
 #if (!DOUBLE_BUFFERED)
     loadDevToSmem_generic<SYRK_WIDTH>( (volatile double*)as, bs, a, b, bx, by, offa, lda, ldb, n, i, k );
@@ -478,8 +478,8 @@ cu_multisyrk_r4x4(
     if (i + SYRK_WIDTH < k) {
       loadDevToSmem_generic<SYRK_WIDTH>( as2, bs2, a, b, bx, by, offa, lda, ldb, n, i + SYRK_WIDTH, k );
     }
-#endif  
-    
+#endif
+
     #pragma unroll
     for ( int ix = 0; ix < SYRK_WIDTH; ix++) {
       for ( int iy = 0; iy < 4; iy++ ) {
@@ -491,16 +491,16 @@ cu_multisyrk_r4x4(
     }
 
     __syncthreads();
-    
+
 #if (DOUBLE_BUFFERED)
     i += SYRK_WIDTH;
-    
+
     if (i >= k) break;
-    
+
     if (i + SYRK_WIDTH < k) {
       loadDevToSmem_generic<SYRK_WIDTH>( as, bs, a, b, bx, by, offa, lda, ldb, n, i + SYRK_WIDTH, k );
     }
-    
+
     #pragma unroll
     for ( int ix = 0; ix < SYRK_WIDTH; ix++) {
       for ( int iy = 0; iy < 4; iy++ ) {
@@ -509,10 +509,10 @@ cu_multisyrk_r4x4(
         s[iy*4 + 2] += as2[threadIdx.x + 32 * ix + 16]*bs2[threadIdx.y + 8*iy + 32 * ix];
         s[iy*4 + 3] += as2[threadIdx.x + 32 * ix + 24]*bs2[threadIdx.y + 8*iy + 32 * ix];
       }
-    }  
-#endif  
+    }
+#endif
   }
-  
+
   for ( int iy = 0; iy < 4; iy++ )
     for ( int ix = 0; ix < 4; ix++ ) {
       int x = threadIdx.x + (ix + bx*4)*8;
@@ -538,7 +538,7 @@ cu_syrk_r4x4(
 
   for ( int i = 0; i < k; i += 4 ) {
 
-    loadDevToSmem_generic< 4 >( as, bs, a, b, blockIdx.x, blockIdx.y, 0, lda, ldb, 
+    loadDevToSmem_generic< 4 >( as, bs, a, b, blockIdx.x, blockIdx.y, 0, lda, ldb,
                               n, i, k );
     __syncthreads();
 
@@ -615,7 +615,7 @@ void spral_ssids_dsyrk(cudaStream_t *stream, int n, int m, int k, double alpha,
 }
 
 void spral_ssids_multidsyrk(cudaStream_t *stream, bool posdef, int nb,
-      int* stat, struct multielm_data* mdata, 
+      int* stat, struct multielm_data* mdata,
       struct multinode_fact_type *ndata) {
   dim3 threads(8,8);
   for ( int i = 0; i < nb; i += MAX_CUDA_BLOCKS ) {

--- a/src/ssids/gpu/kernels/syrk.cu
+++ b/src/ssids/gpu/kernels/syrk.cu
@@ -4,6 +4,12 @@
  *          Jeremy Appleyard (NVIDIA)
  */
 
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
 #include <device_launch_parameters.h>


### PR DESCRIPTION
Resolves #68

As pointed out in #68 , there are still some spurious longs in the C++ codebase that cause major issues for Windows users since that platform uses 32-bit longs.

This PR hopefully addresses the issue by changing all remaining `long` to `int64_t` in both the SSIDS C++ cpu codes as well as a few of the CUDA GPU kernels.