### PR TITLE
Use C_INT64_T in METIS wrappers

### DIFF
--- a/src/metis4_wrapper.F90
+++ b/src/metis4_wrapper.F90
@@ -10,7 +10,7 @@ module spral_metis_wrapper
   private
   public :: metis_order ! Calls metis on a symmetric matrix
 
-  integer, parameter :: long = C_LONG_LONG
+  integer, parameter :: long = C_INT64_T
 
   integer, parameter :: ERROR_ALLOC = -1
   integer, parameter :: ERROR_N_OOR = -2

--- a/src/metis5_wrapper.F90
+++ b/src/metis5_wrapper.F90
@@ -16,7 +16,7 @@ module spral_metis_wrapper
    private
    public :: metis_order ! Calls metis on a symmetric matrix
 
-   integer, parameter :: long = C_LONG_LONG
+   integer, parameter :: long = C_INT64_T
 
 #if SPRAL_HAVE_METIS_H
 ! metis header is available, check for index types 


### PR DESCRIPTION
Prefer `C_INT64_T` to `C_LONG_LONG` in METIS wrappers