### PR TITLE
Fix documentation for pivot_method option

### DIFF
--- a/doc/C/ssids.rst
+++ b/doc/C/ssids.rst
@@ -523,18 +523,18 @@ Derived types
       Pivot method to be used on CPU, one of:
 
       +-------------+----------------------------------------------------------+
-      | 0           | Aggressive a posteori pivoting. Cholesky-like            |
+      | 1           | Aggressive a posteori pivoting. Cholesky-like            |
       |             | communication pattern is used, but a single failed pivot |
       |             | requires restart of node factorization and potential     |
       |             | recalculation of all uneliminated entries.               |
       +-------------+----------------------------------------------------------+
-      | 1 (default) | Block a posteori pivoting. A failed pivot only requires  |
+      | 2 (default) | Block a posteori pivoting. A failed pivot only requires  |
       |             | recalculation of entries within its own block column.    |
       +-------------+----------------------------------------------------------+
-      | 2           | Threshold partial pivoting. Not parallel.                |
+      | 3           | Threshold partial pivoting. Not parallel.                |
       +-------------+----------------------------------------------------------+
 
-      Default is `1`.
+      Default is `2`.
 
    .. c:member:: double small
    

--- a/doc/Fortran/ssids.rst
+++ b/doc/Fortran/ssids.rst
@@ -427,18 +427,18 @@ Derived types
    :f logical action [default=.true.]: continue factorization of singular matrix
       on discovery of zero pivot if true (a warning is issued), or abort if
       false.
-   :f integer pivot_method [default=1]: Pivot method to be used on CPU, one of:
+   :f integer pivot_method [default=2]: Pivot method to be used on CPU, one of:
 
       +-------------+----------------------------------------------------------+
-      | 0           | Aggressive a posteori pivoting. Cholesky-like            |
+      | 1           | Aggressive a posteori pivoting. Cholesky-like            |
       |             | communication pattern is used, but a single failed pivot |
       |             | requires restart of node factorization and potential     |
       |             | recalculation of all uneliminated entries.               |
       +-------------+----------------------------------------------------------+
-      | 1 (default) | Block a posteori pivoting. A failed pivot only requires  |
+      | 2 (default) | Block a posteori pivoting. A failed pivot only requires  |
       |             | recalculation of entries within its own block column.    |
       +-------------+----------------------------------------------------------+
-      | 2           | Threshold partial pivoting. Not parallel.                |
+      | 3           | Threshold partial pivoting. Not parallel.                |
       +-------------+----------------------------------------------------------+
 
    :f real small [default=1d-20]: threshold below which an entry is treated as

--- a/src/ssids/datatypes.f90
+++ b/src/ssids/datatypes.f90
@@ -253,9 +253,9 @@ module spral_ssids_datatypes
        ! Otherwise, terminates with error SSIDS_ERROR_SINGULAR.
      integer :: pivot_method = PIVOT_METHOD_APP_BLOCK
        ! Type of pivoting to use on CPU side:
-       ! 0 - A posteori pivoting, roll back entire front on pivot failure
-       ! 1 - A posteori pivoting, roll back on block column level for failure
-       ! 2 - Traditional threshold partial pivoting (serial, inefficient!)
+       ! 1 - A posteori pivoting, roll back entire front on pivot failure
+       ! 2 - A posteori pivoting, roll back on block column level for failure
+       ! 3 - Traditional threshold partial pivoting (serial, inefficient!)
      real(wp) :: small = 1e-20_wp ! Minimum pivot size (absolute value of a
        ! pivot must be of size at least small to be accepted).
      real(wp) :: u = 0.01


### PR DESCRIPTION
The values for this option were shifted by 1 in ece8720f, but seems like the documentation was not updated accordingly (actually, some of the doc was only introduced later with the old values in 79041f8b and f4199ecc). This updates the documentation to correspond to the values used in the code:
https://github.com/ralna/spral/blob/d385d2c9e858366d257cafaaf05760ffa6543e26/src/ssids/cpu/cpu_iface.hxx#L13-L17
https://github.com/ralna/spral/blob/d385d2c9e858366d257cafaaf05760ffa6543e26/src/ssids/datatypes.f90#L68-L71
https://github.com/ralna/spral/blob/d385d2c9e858366d257cafaaf05760ffa6543e26/src/ssids/datatypes.f90#L254