### PR TITLE
Fix num_factor and num_flops info after factorization

### DIFF
--- a/src/ssids/cpu/SmallLeafNumericSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafNumericSubtree.hxx
@@ -377,6 +377,10 @@ private:
       /* Record information */
       node->ndelay_out = n - node->nelim;
       stats.num_delay += node->ndelay_out;
+      for (int64_t j = m; j >= m-(node->nelim)+1; --j) {
+         stats.num_factor += j;
+         stats.num_flops += j*j;
+      }
 
       /* Mark as no contribution if we make no contribution */
       if(node->nelim==0 && !node->first_child) {

--- a/src/ssids/cpu/ThreadStats.cxx
+++ b/src/ssids/cpu/ThreadStats.cxx
@@ -18,6 +18,8 @@ ThreadStats& ThreadStats::operator+=(ThreadStats const& other) {
    flag = (flag<0 || other.flag<0) ? std::min(flag, other.flag) // error
                                    : std::max(flag, other.flag);// warning/pass
    num_delay += other.num_delay;
+   num_factor += other.num_factor;
+   num_flops += other.num_flops;
    num_neg += other.num_neg;
    num_two += other.num_two;
    num_zero += other.num_zero;

--- a/src/ssids/cpu/ThreadStats.hxx
+++ b/src/ssids/cpu/ThreadStats.hxx
@@ -47,6 +47,8 @@ public:
 struct ThreadStats {
    Flag flag = Flag::SUCCESS; ///< Error flag for thread
    int num_delay = 0;   ///< Number of delays
+   int64_t num_factor = 0;    ///< Number of entries in factors
+   int64_t num_flops = 0;     ///< Number of floating point operations
    int num_neg = 0;     ///< Number of negative pivots
    int num_two = 0;     ///< Number of 2x2 pivots
    int num_zero = 0;    ///< Number of zero pivots

--- a/src/ssids/cpu/cpu_iface.f90
+++ b/src/ssids/cpu/cpu_iface.f90
@@ -39,6 +39,8 @@ module spral_ssids_cpu_iface
    type, bind(C) :: cpu_factor_stats
       integer(C_INT) :: flag
       integer(C_INT) :: num_delay
+      integer(C_INT64_T) :: num_factor
+      integer(C_INT64_T) :: num_flops
       integer(C_INT) :: num_neg
       integer(C_INT) :: num_two
       integer(C_INT) :: num_zero
@@ -79,6 +81,8 @@ subroutine cpu_copy_stats_out(cstats, finform)
       finform%flag = max(finform%flag, cstats%flag) ! success or warning
    endif
    finform%num_delay    = finform%num_delay + cstats%num_delay
+   finform%num_factor   = finform%num_factor + cstats%num_factor
+   finform%num_flops    = finform%num_flops + cstats%num_flops
    finform%num_neg      = finform%num_neg + cstats%num_neg
    finform%num_two      = finform%num_two + cstats%num_two
    finform%maxfront     = max(finform%maxfront, cstats%maxfront)

--- a/src/ssids/cpu/factor.hxx
+++ b/src/ssids/cpu/factor.hxx
@@ -118,6 +118,10 @@ void factor_node_indef(
    /* Record information */
    node.ndelay_out = n - node.nelim;
    stats.num_delay += node.ndelay_out;
+   for (int64_t j = m; j >= m-(node.nelim)+1; --j) {
+      stats.num_factor += j;
+      stats.num_flops += j*j;
+   }
 
    /* Mark as no contribution if we make no contribution */
    if(node.nelim==0 && !node.first_child && snode.contrib.size()==0) {
@@ -157,6 +161,10 @@ void factor_node_posdef(
       return;
    }
    node.nelim = n;
+   for (int64_t j = m; j >= m-(node.nelim)+1; --j) {
+      stats.num_factor += j;
+      stats.num_flops += j*j;
+   }
 
    /* Record information */
    node.ndelay_out = 0;

--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -825,6 +825,8 @@ contains
 
     ! Initialize
     inform = akeep%inform
+    inform%num_factor = 0
+    inform%num_flops = 0
     st = 0
     n = akeep%n
 


### PR DESCRIPTION
According to the documentation, `num_factor` and `num_flops` should hold the values "without pivoting after analyse phase, with pivoting after factorize phase". The latter does not seem to work correctly:

* `num_factor` and `num_flops` are initialized with the values from `akeep`, i.e. with the values from the analyse phase:
https://github.com/ralna/spral/blob/353f104a892552450c882530c5ec424914488fb3/src/ssids/ssids.f90#L827 The actually counted values during factorization are therefore added on top. That causes the result to be up to twice as large (exactly twice in the posdef case) of what it should be. As a fix, `num_factor` and `num_flops` are now initialized to `0`.
* The CPU factorization does not seem to count these statistics at all. Together with the issue mentioned before, this causes `num_factor` and `num_flops` to be reported correctly after the factorize phase in the posdef case. In the indef case, any extra nnz or flops due to delays would not be reported though. This commit adds counting of these stats to the CPU factorization code.

Counting for the CPU code is taken directly from how it is done in the GPU code:
https://github.com/ralna/spral/blob/353f104a892552450c882530c5ec424914488fb3/src/ssids/gpu/factor.f90#L1441-L1444 I thought about simplifying the loop a bit (e.g. I am not quite sure why the iteration is done backwards) or even implementing closed form solutions for these sums. I decided to mirror the exact implementation from the GPU code (which is also the same as in HSL_MA97) though, as no change seemed relevant enough to me ([clang even likes to emit closed form solutions on its own](https://godbolt.org/z/T6r99TehM)).

I tested a few matrices to make sure that the values after analysis and factorization are the same in the posdef case. For the indef case I set `nemin=8` and `pivot_method=3` and compared to HSL_MA97 with default options, both using Metis 4 ordering. On some matrices I see identical values that way. On others the results are pretty close though not identical, but that is probably an expected differece in pivoting between the two solvers.

All these tests are on CPU only. That also means that I could not actually verify whether the issue of almost double the values being reported happens as described on GPU, without these changes. It is my best understanding of the code though.
