### PR TITLE
Fix maxfront info and add maxsupernode for previous behaviour

### DIFF
--- a/doc/C/ssids.rst
+++ b/doc/C/ssids.rst
@@ -608,6 +608,11 @@ Derived types
       Maximum front size (without pivoting after analyse phase, with pivoting
       after factorize phase).
 
+   .. c:member:: int maxsupernode
+
+      Maximum supernode size (without pivoting after analyse phase, with
+      pivoting after factorize phase).
+
    .. c:member:: int num_delay
    
       Number of delayed pivots. That is, the total number of fully-summed

--- a/doc/Fortran/ssids.rst
+++ b/doc/Fortran/ssids.rst
@@ -473,6 +473,8 @@ Derived types
    :f integer maxdepth: maximum depth of the assembly tree.
    :f integer maxfront: maximum front size (without pivoting after analyse
       phase, with pivoting after factorize phase).
+   :f integer maxsupernode: maximum supernode size (without pivoting after
+      analyse phase, with pivoting after factorize phase).
    :f integer num_delay: number of delayed pivots. That is, the total
       number of fully-summed variables that were passed to the father node
       because of stability considerations. If a variable is passed further

--- a/driver/spral_ssids.F90
+++ b/driver/spral_ssids.F90
@@ -204,6 +204,7 @@ program run_prob
        inform%matrix_rank-inform%num_neg
   print "(a6, i10)", "2x2piv:", inform%num_two
   print "(a6, i10)", "maxfront:", inform%maxfront
+  print "(a6, i10)", "maxsupernode:", inform%maxsupernode
   print "(a6, i10)", "not_first_pass:", inform%not_first_pass
   print "(a6, i10)", "not_second_pass:", inform%not_second_pass
 

--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -52,7 +52,8 @@ struct spral_ssids_inform {
    int stat;
    int cuda_error;
    int cublas_error;
-   char unused[80]; // Allow for future expansion
+   int maxsupernode;
+   char unused[76]; // Allow for future expansion
 };
 
 /************************************

--- a/interfaces/C/ssids.f90
+++ b/interfaces/C/ssids.f90
@@ -43,7 +43,8 @@ module spral_ssids_ciface
      integer(C_INT) :: stat
      integer(C_INT) :: cuda_error
      integer(C_INT) :: cublas_error
-     character(C_CHAR) :: unused(80)
+     integer(C_INT) :: maxsupernode
+     character(C_CHAR) :: unused(76)
   end type spral_ssids_inform
 
 contains
@@ -86,6 +87,7 @@ contains
     cinform%matrix_rank           = finform%matrix_rank
     cinform%maxdepth              = finform%maxdepth
     cinform%maxfront              = finform%maxfront
+    cinform%maxsupernode          = finform%maxsupernode
     cinform%num_delay             = finform%num_delay
     cinform%num_factor            = finform%num_factor
     cinform%num_flops             = finform%num_flops

--- a/src/ssids/anal.F90
+++ b/src/ssids/anal.F90
@@ -1107,7 +1107,7 @@ contains
        blkn = akeep%sptr(i+1) - akeep%sptr(i)
        blkm = int(akeep%rptr(i+1) - akeep%rptr(i))
        level(i) = level(akeep%sparent(i)) + 1
-       inform%maxfront = max(inform%maxfront, blkn)
+       inform%maxfront = max(inform%maxfront, blkm)
        inform%maxdepth = max(inform%maxdepth, level(i))
     end do
     deallocate(level, stat=st)

--- a/src/ssids/anal.F90
+++ b/src/ssids/anal.F90
@@ -1108,6 +1108,7 @@ contains
        blkm = int(akeep%rptr(i+1) - akeep%rptr(i))
        level(i) = level(akeep%sparent(i)) + 1
        inform%maxfront = max(inform%maxfront, blkm)
+       inform%maxsupernode = max(inform%maxsupernode, blkn)
        inform%maxdepth = max(inform%maxdepth, level(i))
     end do
     deallocate(level, stat=st)

--- a/src/ssids/cpu/NumericSubtree.hxx
+++ b/src/ssids/cpu/NumericSubtree.hxx
@@ -180,6 +180,9 @@ public:
                   int nrow = symb_[ni].nrow + nodes_[ni].ndelay_in;
                   thread_stats[this_thread].maxfront =
                      std::max(thread_stats[this_thread].maxfront, nrow);
+                  int ncol = symb_[ni].ncol + nodes_[ni].ndelay_in;
+                  thread_stats[this_thread].maxsupernode =
+                     std::max(thread_stats[this_thread].maxsupernode, ncol);
                   
                   // Factorization
                   factor_node<posdef>

--- a/src/ssids/cpu/SmallLeafNumericSubtree.hxx
+++ b/src/ssids/cpu/SmallLeafNumericSubtree.hxx
@@ -60,6 +60,8 @@ public:
          // Update stats
          int nrow = symb_.symb_[ni].nrow;
          stats.maxfront = std::max(stats.maxfront, nrow);
+         int ncol = symb_.symb_[ni].ncol;
+         stats.maxsupernode = std::max(stats.maxsupernode, ncol);
          // Factorization
          factor_node_posdef
             (1.0, symb_.symb_[ni], old_nodes_[ni], options, stats);
@@ -203,6 +205,8 @@ public:
          // Update stats
          int nrow = symb_.symb_[ni].nrow + old_nodes_[ni].ndelay_in;
          stats.maxfront = std::max(stats.maxfront, nrow);
+         int ncol = symb_.symb_[ni].ncol + old_nodes_[ni].ndelay_in;
+         stats.maxsupernode = std::max(stats.maxsupernode, ncol);
 
          // Factorization
          factor_node

--- a/src/ssids/cpu/ThreadStats.cxx
+++ b/src/ssids/cpu/ThreadStats.cxx
@@ -24,6 +24,7 @@ ThreadStats& ThreadStats::operator+=(ThreadStats const& other) {
    num_two += other.num_two;
    num_zero += other.num_zero;
    maxfront = std::max(maxfront, other.maxfront);
+   maxsupernode = std::max(maxsupernode, other.maxsupernode);
    not_first_pass += other.not_first_pass;
    not_second_pass += other.not_second_pass;
 

--- a/src/ssids/cpu/ThreadStats.hxx
+++ b/src/ssids/cpu/ThreadStats.hxx
@@ -53,6 +53,7 @@ struct ThreadStats {
    int num_two = 0;     ///< Number of 2x2 pivots
    int num_zero = 0;    ///< Number of zero pivots
    int maxfront = 0;    ///< Maximum front size
+   int maxsupernode = 0;      ///< Maximum supernode size
    int not_first_pass = 0;    ///< Number of pivots not eliminated in APP
    int not_second_pass = 0;   ///< Number of pivots not eliminated in APP or TPP
 

--- a/src/ssids/cpu/cpu_iface.f90
+++ b/src/ssids/cpu/cpu_iface.f90
@@ -45,6 +45,7 @@ module spral_ssids_cpu_iface
       integer(C_INT) :: num_two
       integer(C_INT) :: num_zero
       integer(C_INT) :: maxfront
+      integer(C_INT) :: maxsupernode
       integer(C_INT) :: not_first_pass
       integer(C_INT) :: not_second_pass
    end type cpu_factor_stats
@@ -86,6 +87,7 @@ subroutine cpu_copy_stats_out(cstats, finform)
    finform%num_neg      = finform%num_neg + cstats%num_neg
    finform%num_two      = finform%num_two + cstats%num_two
    finform%maxfront     = max(finform%maxfront, cstats%maxfront)
+   finform%maxsupernode = max(finform%maxsupernode, cstats%maxsupernode)
    finform%not_first_pass = finform%not_first_pass + cstats%not_first_pass
    finform%not_second_pass = finform%not_second_pass + cstats%not_second_pass
    finform%matrix_rank  = finform%matrix_rank - cstats%num_zero

--- a/src/ssids/datatypes.f90
+++ b/src/ssids/datatypes.f90
@@ -160,6 +160,7 @@ module spral_ssids_datatypes
      integer :: cuda_error = 0
      integer :: cublas_error = 0
      integer :: maxfront = 0 ! Maximum front size
+     integer :: maxsupernode = 0 ! Maximum supernode size
      integer(long) :: num_factor = 0_long ! Number of entries in factors
      integer(long) :: num_flops = 0_long ! Number of floating point operations
      integer :: num_delay = 0 ! Number of delayed variables

--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -491,7 +491,7 @@ contains
           blkn = sptr(node+1) - sptr(node) + ndelay
           blkm = int(rptr(node+1) - rptr(node)) + ndelay
     
-          stats%maxfront = max(stats%maxfront, blkn)
+          stats%maxfront = max(stats%maxfront, blkm)
 
           ! Allocate memory for the local permutation (lperm).
           call smalloc(alloc, nodes(node)%perm, blkn+0_long, &

--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -492,6 +492,7 @@ contains
           blkm = int(rptr(node+1) - rptr(node)) + ndelay
     
           stats%maxfront = max(stats%maxfront, blkm)
+          stats%maxsupernode = max(stats%maxsupernode, blkn)
 
           ! Allocate memory for the local permutation (lperm).
           call smalloc(alloc, nodes(node)%perm, blkn+0_long, &

--- a/src/ssids/gpu/subtree.f90
+++ b/src/ssids/gpu/subtree.f90
@@ -431,6 +431,7 @@ contains
    end if
    if (stats%st .ne. 0) inform%stat = stats%st
    inform%maxfront = max(inform%maxfront, stats%maxfront)
+   inform%maxsupernode = max(inform%maxsupernode, stats%maxsupernode)
    inform%num_factor = inform%num_factor+stats%num_factor
    inform%num_flops = inform%num_flops+stats%num_flops
    inform%num_delay = inform%num_delay+stats%num_delay

--- a/src/ssids/inform.f90
+++ b/src/ssids/inform.f90
@@ -25,6 +25,7 @@ module spral_ssids_inform
      integer :: matrix_rank = 0 ! Rank of matrix (anal=structral, fact=actual)
      integer :: maxdepth = 0 ! Maximum depth of tree
      integer :: maxfront = 0 ! Maximum front size
+     integer :: maxsupernode = 0 ! Maximum supernode size
      integer :: num_delay = 0 ! Number of delayed variables
      integer(long) :: num_factor = 0_long ! Number of entries in factors
      integer(long) :: num_flops = 0_long ! Number of floating point operations
@@ -195,6 +196,7 @@ contains
     this%matrix_rank = this%matrix_rank + other%matrix_rank
     this%maxdepth = max(this%maxdepth, other%maxdepth)
     this%maxfront = max(this%maxfront, other%maxfront)
+    this%maxsupernode = max(this%maxsupernode, other%maxsupernode)
     this%num_delay = this%num_delay + other%num_delay
     this%num_factor = this%num_factor + other%num_factor
     this%num_flops = this%num_flops + other%num_flops

--- a/src/ssids/ssids.f90
+++ b/src/ssids/ssids.f90
@@ -1068,12 +1068,14 @@ contains
        write (options%unit_diagnostics,'(/a)') &
             ' Completed factorisation with:'
        write (options%unit_diagnostics, &
-            '(a,2(/a,i12),2(/a,es12.4),5(/a,i12))') &
+            '(a,3(/a,i12),2(/a,es12.4),5(/a,i12))') &
             ' information parameters (inform%) :', &
             ' flag                   Error flag                               = ',&
             inform%flag, &
             ' maxfront               Maximum frontsize                        = ',&
             inform%maxfront, &
+            ' maxsupernode           Maximum supernode size                   = ',&
+            inform%maxsupernode, &
             ' num_factor             Number of entries in L                   = ',&
             real(inform%num_factor), &
             ' num_flops              Number of flops performed                = ',&


### PR DESCRIPTION
Fixes #110

* `maxfactor` should be the maximum number of rows across all nodes. That required changing `blkn` to `blkm` in GPU factorization and analysis
* To still have the information that was previously computed in GPU factorization and analysis, added `maxsupernode`. For that, I added the corresponding analogous code wherever `maxfront` appeared. A special case was the info struct for the C interface. I opted to place `maxsupernode` into the reserved `unused` space and with that consume 4 bytes of it. That keeps `sizeof(spral_ssids_inform)` and `offsetof` all previous members equal, which I assume was the intention behind the `unused` member.