### PR TITLE
Let configure detect OPENMP_FCFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(OPENMP_CFLAGS) \
 				$(HWLOC_CFLAGS) -std=c99
 AM_CXXFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -std=c++11 \
 				  $(OPENMP_CXXFLAGS) $(GTG_INCLUDE) $(HWLOC_CFLAGS)
-AM_FCFLAGS = $(OPENMP_CXXFLAGS) # assume CXX and FC use same flags...
+AM_FCFLAGS = $(OPENMP_FCFLAGS)
 
 # FIXME: make below configurable
 if HAVE_NVCC

--- a/configure.ac
+++ b/configure.ac
@@ -35,16 +35,17 @@ AC_PROG_F77
 AC_PROG_FC
 AC_PROG_RANLIB
 
-# Add OpenMP support, set language standards
-AC_LANG_PUSH(C)
-AC_PROG_CC_C99
-AC_LANG_POP(C)
+# Add OpenMP support
 AS_IF([test "x$enable_openmp" != "xno"], [
    AC_LANG_PUSH(C)
    AC_OPENMP
-   AC_LANG(C++)
+   AC_LANG_POP(C)
+   AC_LANG_PUSH(C++)
    AC_OPENMP
    AC_LANG_POP(C++)
+   AC_LANG_PUSH(Fortran)
+   AC_OPENMP
+   AC_LANG_POP(Fortran)
    ])
 AM_CONDITIONAL([HAVE_OPENMP], [test -n "$OPENMP_CXXFLAGS"])
 


### PR DESCRIPTION
Resolves #114 

Correctly detect OpenMP Fortran compiler flags as opposed to assuming they are the same as the C++ compiler (which breaks when matching compilers are not used, e.g. nagfor and gcc/g++). For details see autoconf AC_OPENMP docs:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Generic-Compiler-Characteristics.html

Also remove the obsolete AC_PROG_CC_C99 macro:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Obsolete-Macros.html#index-AC_005fPROG_005fCC_005fC99-1