### PR TITLE
Add missing stdint includes

### DIFF
--- a/include/spral_random_matrix.h
+++ b/include/spral_random_matrix.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <stdbool.h>
+#include <stdint.h>
 #include "spral_matrix_util.h"
 
 #define SPRAL_RANDOM_MATRIX_FINDEX        1

--- a/src/ssids/cpu/ThreadStats.hxx
+++ b/src/ssids/cpu/ThreadStats.hxx
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace spral { namespace ssids { namespace cpu {


### PR DESCRIPTION
Some files using `int64_t` were not including stdint header. The one in `ThreadStats.hxx` caused compilation error for me on MSYS2 for Windows. The other one I noticed during greping.