### PR TITLE
Allow compilation of ldlt tests if targeting Windows

### DIFF
--- a/tests/ssids/kernels/AlignedAllocator.hxx
+++ b/tests/ssids/kernels/AlignedAllocator.hxx
@@ -7,6 +7,9 @@
 
 #include <cstddef>
 #include <cstdlib>
+#ifdef _WIN32
+# include <malloc.h>  // _aligned_malloc, _aligned_free
+#endif
 #include <new>
 
 namespace spral { namespace test {
@@ -32,7 +35,9 @@ public:
    T* allocate(size_t n) {
       // NB: size allocated must be multiple of alignment
       size_t sz = alignment*( ( n*sizeof(T)-1 )/alignment + 1);
-#ifdef _ISOC11_SOURCE /* FIXME: is this ever true in C++? */
+#ifdef _WIN32
+      auto ptr = _aligned_malloc(sz, alignment);
+#elif defined(_ISOC11_SOURCE) /* FIXME: is this ever true in C++? */
       auto ptr = aligned_alloc(alignment, sz);
 #else /* _POSIX_C_SOURCE > 200112L || _XOPEN_SOURCE >= 600 */
       void *ptr;
@@ -44,7 +49,11 @@ public:
    }
 
    void deallocate(T *p, size_t n) {
+#ifdef _WIN32
+      _aligned_free(p);
+#else
       free(p);
+#endif
    }
 };
 


### PR DESCRIPTION
Use Windows-specific `_aligned_malloc` and `_aligned_free` for implementing the `AlignedAllocator` in the ldlt tests on Windows.

I did consider making this completely platform-independent by upping the C-standard from C99 to C11 and just using `aligned_alloc`. Unfortunately, Microsoft does not support it (see https://learn.microsoft.com/en-us/cpp/standard-library/cstdlib?view=msvc-170#remarks-6) and so MinGW does not seem to provide it either. One could at least remove the posix-specific branch but that did not seem worth the standard change.

I believe another option would be to implement the aligning as in the `SimpleAlignedAlloc`: https://github.com/ralna/spral/blob/b1b7397f74f1ed91eb419f37a757a01918d64a30/src/ssids/cpu/SimpleAlignedAlloc.hxx#L37-L52 However, this was introduced in https://github.com/ralna/spral/commit/fea9ed81dedce4cc91a1c4746f87bc15b697f584 for "testing purposes" and does not seem to be used or tested anywhere at the moment. The only mention of it is commented out: https://github.com/ralna/spral/blob/b1b7397f74f1ed91eb419f37a757a01918d64a30/src/ssids/cpu/NumericSubtree.hxx#L35 So with those not entirely obvious `reinterpret_cast`s for storing the original allocated pointer this did not seem like the best option to me either.