### PR TITLE
don't use omp_lib if not compiling with OpenMP

### DIFF
--- a/src/ssids/fkeep.F90
+++ b/src/ssids/fkeep.F90
@@ -12,7 +12,7 @@
 
 module spral_ssids_fkeep
    use, intrinsic :: iso_c_binding
-   use :: omp_lib
+!$ use :: omp_lib
    use spral_ssids_akeep, only : ssids_akeep
    use spral_ssids_contrib, only : contrib_type
    use spral_ssids_datatypes


### PR DESCRIPTION
I have this change lying around for some years now. I need this to compile with `--disable-openmp`. It is similar to what happens in other files.