### PR TITLE
Fix returned stats being uninitialised on aborted factorization if OpenMP disabled

### DIFF
--- a/src/ssids/cpu/NumericSubtree.hxx
+++ b/src/ssids/cpu/NumericSubtree.hxx
@@ -80,6 +80,10 @@ public:
       for(int i=0; i<num_threads; ++i)
          work.emplace_back(PAGE_SIZE);
 
+      // initialise stats already so we can safely early-return in case of
+      // failure if not compiled with OpenMP (instead of omp cancel)
+      stats = ThreadStats();
+
       // Each node is depend(inout) on itself and depend(in) on its parent.
       // Whilst this isn't really what's happening it does ensure our
       // ordering is correct: each node cannot be scheduled until all its
@@ -234,8 +238,7 @@ public:
       } // taskgroup
 
 
-      // Reduce thread_stats
-      stats = ThreadStats(); // initialise
+      // Reduce thread_stats (stats already initialised above)
       for(auto tstats : thread_stats)
          stats += tstats;
       if(stats.flag < 0) return;


### PR DESCRIPTION
If configured with `--disable-openmp`, running `ssids_test` with valgrind reveals dependency on uninitialised values. The issue is that the early returns in `NumericSubtree`, e.g. https://github.com/ralna/spral/blob/c50996a366c5e8d113633ddbf7a37a4bfc301a66/src/ssids/cpu/NumericSubtree.hxx#L115-L122 return `stats` before they have been initialized here: https://github.com/ralna/spral/blob/c50996a366c5e8d113633ddbf7a37a4bfc301a66/src/ssids/cpu/NumericSubtree.hxx#L237-L241 These were introduced in 2288ac81 as alternative to the `omp cancel` for when compiling without OpenMP.

This moves up the initialisation of `stats` such that they can be returned safely from within the loops.