### PR TITLE
Avoid default-init overhead for lookup map in assemble_pre

### DIFF
--- a/src/ssids/cpu/kernels/assemble.hxx
+++ b/src/ssids/cpu/kernels/assemble.hxx
@@ -160,7 +160,8 @@ void assemble_pre(
    typename FADoubleTraits::allocator_type factor_alloc_double(factor_alloc);
    typedef typename std::allocator_traits<FactorAlloc>::template rebind_traits<int> FAIntTraits;
    typename FAIntTraits::allocator_type factor_alloc_int(factor_alloc);
-   typedef typename std::allocator_traits<PoolAlloc>::template rebind_alloc<int> PoolAllocInt;
+   typedef typename std::allocator_traits<PoolAlloc>::template rebind_traits<int> PAIntTraits;
+   typename PAIntTraits::allocator_type pool_alloc_int(pool_alloc);
 
    /* Count incoming delays and determine size of node */
    node.ndelay_in = 0;
@@ -228,7 +229,11 @@ void assemble_pre(
    /* Build lookup vector, allowing for insertion of delayed vars */
    /* Note that while rlist[] is 1-indexed this is fine so long as lookup
     * is also 1-indexed (which it is as it is another node's rlist[] */
-   std::vector<int, PoolAllocInt> map(n+1, PoolAllocInt(pool_alloc));
+   const auto map_deleter = [&pool_alloc_int, n](int* p) {
+      PAIntTraits::deallocate(pool_alloc_int, p, n+1);
+   };
+   auto map = std::unique_ptr<int[], decltype(map_deleter)>(
+         PAIntTraits::allocate(pool_alloc_int, n+1), map_deleter);
    for(int i=0; i<snode.ncol; i++)
       map[ snode.rlist[i] ] = i;
    for(int i=snode.ncol; i<snode.nrow; i++)


### PR DESCRIPTION
With e3b35456, `std::vector` started to take care of the memory for the lookup map in `assemble_pre` to avoid having to call `allocate` and `deallocate` manually. But `std::vector` also default initializes all values on construction, meaning that this change introduced an overhead of always zeroing the map values initially.

Indeed it does not need to be zero'd, as all used values are set upon building it. As it needs to be of size `n` to be able to map any row index, zeroing it can actually be somewhat costly, especially since it is repeated for each `assemble_pre`. This change replaces the `std::vector` with `std::unique_ptr` to avoid the repeated unnecessary zeroing but still keep the implementation RAII.

[Here](https://seafile.zfn.uni-bremen.de/d/b4d5a00a6d7044c99553/) and in the plots below are some benchmarks with the same setup as in #119, except that repetitions for a matrix are run at different times and on random cores to try to highlight the baseline noise. For most test matrices I see no measureable change, but for a few larger matrices (especially the DIMACS10 group) there are small but significant performance improvements.

Note that e3b35456 only changed `assemple_pre`, so this only deals with that function too. `assemble_post` does not use an RAII solution yet. If desired it should be possible to introduce `std::unique_ptr` for it as well, supposedly without any influence on performance.

![benchmark_comparison_all](https://github.com/ralna/spral/assets/44684927/c8b4bade-02f0-4b19-8510-daa10e9ae753)
![benchmark_comparison_DIMACS10](https://github.com/ralna/spral/assets/44684927/ee507785-bc41-4ecf-bd54-a58d430df8ea)
