### PR TITLE
Fix out of bounds std::vector subscript operator usage

### DIFF
--- a/src/ssids/cpu/NumericSubtree.hxx
+++ b/src/ssids/cpu/NumericSubtree.hxx
@@ -95,7 +95,7 @@ public:
       {
          /* Loop over small leaf subtrees */
          for(unsigned int si=0; si<symb_.small_leafs_.size(); ++si) {
-            auto* parent_lcol = &nodes_[symb_.small_leafs_[si].get_parent()];
+            auto* parent_lcol = nodes_.data() + symb_.small_leafs_[si].get_parent();
             #pragma omp task default(none) \
                firstprivate(si) \
                shared(aval, abort, options, scaling, thread_stats, work) \
@@ -158,7 +158,7 @@ public:
          for(int ni=0; ni<symb_.nnodes_; ++ni) {
             if(symb_[ni].insmallleaf) continue; // already handled
             auto* this_lcol = &nodes_[ni]; // for depend
-            auto* parent_lcol = &nodes_[symb_[ni].parent]; // for depend
+            auto* parent_lcol = nodes_.data() + symb_[ni].parent; // for depend
             #pragma omp task default(none) \
                firstprivate(ni) \
                shared(aval, abort, child_contrib, options, scaling, \

--- a/src/ssids/cpu/kernels/ldlt_app.cxx
+++ b/src/ssids/cpu/kernels/ldlt_app.cxx
@@ -2386,7 +2386,7 @@ public:
          for(int jblk=0, insert=0, fail_insert=0; jblk<nblk; jblk++) {
             cdata[jblk].move_back(
                   get_ncol(jblk, n, block_size), &perm[jblk*block_size],
-                  &perm[insert], &failed_perm[fail_insert]
+                  &perm[insert], failed_perm.data() + fail_insert
                   );
             insert += cdata[jblk].nelim;
             fail_insert += get_ncol(jblk, n, block_size) - cdata[jblk].nelim;
@@ -2406,7 +2406,7 @@ public:
                      cdata[iblk], cdata[jblk],
                      &failed_diag[jinsert*nfail+ifail],
                      &failed_diag[iinsert*nfail+jfail],
-                     &failed_diag[num_elim*nfail+jfail*nfail+ifail],
+                     failed_diag.data() + (num_elim*nfail+jfail*nfail+ifail),
                      nfail, &a[jblk*block_size*lda+iblk*block_size], lda
                      );
                iinsert += cdata[iblk].nelim;
@@ -2417,14 +2417,14 @@ public:
             copy_failed_rect(
                   get_nrow(nblk-1, m, block_size), get_ncol(jblk, n, block_size),
                   get_ncol(nblk-1, n, block_size), cdata[jblk],
-                  &failed_rect[jfail*(m-n)+(nblk-1)*block_size-n], m-n,
+                  failed_rect.data() + (jfail*(m-n)+(nblk-1)*block_size-n), m-n,
                   &a[jblk*block_size*lda+(nblk-1)*block_size], lda
                   );
             for(int iblk=nblk; iblk<mblk; ++iblk) {
                copy_failed_rect(
                      get_nrow(iblk, m, block_size),
                      get_ncol(jblk, n, block_size), 0, cdata[jblk],
-                     &failed_rect[jfail*(m-n)+iblk*block_size-n], m-n,
+                     failed_rect.data() + (jfail*(m-n)+iblk*block_size-n), m-n,
                      &a[jblk*block_size*lda+iblk*block_size], lda
                      );
             }


### PR DESCRIPTION
Fixes #140. This was the minimum amount of replacements with `.data()` that causes no errors with `-D_GLIBCXX_DEBUG` for me across all tests.