### PR TITLE
Fix licence on SSIDS kernel tests

### DIFF
--- a/tests/ssids/kernels.cxx
+++ b/tests/ssids/kernels.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 

--- a/tests/ssids/kernels/block_ldlt.cxx
+++ b/tests/ssids/kernels/block_ldlt.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "block_ldlt.hxx"
@@ -132,7 +129,7 @@ void print_d(int n, T *d) {
 template <typename T>
 void make_singular(int n, int col1, int col2, T *a, int lda) {
    T *col = new T[n];
-   
+
    T a11 = a[col1*(lda+1)];
    T a21 = (col1 < col2) ? a[col1*lda + col2]
                          : a[col2*lda + col1];
@@ -208,7 +205,7 @@ int test_maxloc(int from, bool zero=false) {
       }
    }
 
-   /* Call both simple and avx versions and check they get the same answer */ 
+   /* Call both simple and avx versions and check they get the same answer */
    T mv1, mv2;
    int rloc1, cloc1, rloc2, cloc2;
 

--- a/tests/ssids/kernels/block_ldlt.hxx
+++ b/tests/ssids/kernels/block_ldlt.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once

--- a/tests/ssids/kernels/cholesky.cxx
+++ b/tests/ssids/kernels/cholesky.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "cholesky.hxx"
@@ -27,7 +24,7 @@ int test_cholesky(int m, int n, int blksz, bool debug=false) {
    /* Take a copy */
    double *l = new double[m*lda];
    memcpy(l, a, m*lda*sizeof(double));
-   
+
    /* Factor first m x n part with our code, generate contrib block */
    if(debug) { printf("PRE:\n"); print_mat(" %e", m, l, lda); }
    int info;

--- a/tests/ssids/kernels/cholesky.hxx
+++ b/tests/ssids/kernels/cholesky.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once

--- a/tests/ssids/kernels/framework.cxx
+++ b/tests/ssids/kernels/framework.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "framework.hxx"
@@ -103,7 +100,7 @@ double backward_error(int n, double const* a, int lda, double const* rhs, int nr
       for(int i=0; i<n; ++i) {
          rhsnorm = std::max(rhsnorm, fabs(rhs[i]));
          residnorm = std::max(residnorm, fabs(resid[i]));
-         if(std::isnan(resid[i])) residnorm = resid[i]; 
+         if(std::isnan(resid[i])) residnorm = resid[i];
          solnnorm = std::max(solnnorm, fabs(r*ldsoln+soln[i]));
       }
 

--- a/tests/ssids/kernels/framework.hxx
+++ b/tests/ssids/kernels/framework.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once

--- a/tests/ssids/kernels/ldlt_app.cxx
+++ b/tests/ssids/kernels/ldlt_app.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "ldlt_app.hxx"
@@ -83,7 +80,7 @@ void solve(int m, int n, const int *perm, const T *l, int ldl, const T *d, const
 template <typename T>
 void make_singular(int n, int col1, int col2, T *a, int lda) {
    T *col = new T[n];
-   
+
    T a11 = a[col1*(lda+1)];
    T a21 = (col1 < col2) ? a[col1*lda + col2]
                          : a[col2*lda + col1];
@@ -411,7 +408,7 @@ template <typename T>
 void print_mat (int n, int *perm, T *a, int lda) {
    for(int i=0; i<n; i++) {
       printf("%d:", perm[i]);
-      for(int j=0; j<n; j++) 
+      for(int j=0; j<n; j++)
          printf(" %le", a[j*lda+i]);
       printf("\n");
    }

--- a/tests/ssids/kernels/ldlt_app.hxx
+++ b/tests/ssids/kernels/ldlt_app.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once

--- a/tests/ssids/kernels/ldlt_nopiv.cxx
+++ b/tests/ssids/kernels/ldlt_nopiv.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "ldlt_nopiv.hxx"
@@ -27,7 +24,7 @@ int test_ldlt(int m, int n, bool debug=false) {
    /* Take a copy */
    double *l = new double[m*lda];
    memcpy(l, a, m*lda*sizeof(double));
-   
+
    /* Factor first m x n part with our code */
    double *work = new double[2*m];
    if(debug) { printf("PRE:\n"); print_mat(" %e", m, l, lda); }

--- a/tests/ssids/kernels/ldlt_nopiv.hxx
+++ b/tests/ssids/kernels/ldlt_nopiv.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once

--- a/tests/ssids/kernels/ldlt_tpp.cxx
+++ b/tests/ssids/kernels/ldlt_tpp.cxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #include "ldlt_tpp.hxx"
@@ -83,7 +80,7 @@ void solve(int m, int n, const int *perm, const T *l, int ldl, const T *d, const
 template <typename T>
 void make_singular(int n, int col1, int col2, T *a, int lda) {
    T *col = new T[n];
-   
+
    T a11 = a[col1*(lda+1)];
    T a21 = (col1 < col2) ? a[col1*lda + col2]
                          : a[col2*lda + col1];
@@ -337,7 +334,7 @@ template <typename T>
 void print_mat (int n, int *perm, T *a, int lda) {
    for(int i=0; i<n; i++) {
       printf("%d:", perm[i]);
-      for(int j=0; j<n; j++) 
+      for(int j=0; j<n; j++)
          printf(" %le", a[j*lda+i]);
       printf("\n");
    }

--- a/tests/ssids/kernels/ldlt_tpp.hxx
+++ b/tests/ssids/kernels/ldlt_tpp.hxx
@@ -2,10 +2,7 @@
  *
  * Authors: Jonathan Hogg (STFC)
  *
- * IMPORTANT: This file is NOT licenced under the BSD licence. If you wish to
- * licence this code, please contact STFC via hsl@stfc.ac.uk
- * (We are currently deciding what licence to release this code under if it
- * proves to be useful beyond our own academic experiments)
+ * Licence: BSD licence, see LICENCE file for details
  *
  */
 #pragma once


### PR DESCRIPTION
Ensure that the SSIDS kernel tests are also licensed under a BSD licence. 