### PR TITLE
[Meson] Compile in release mode by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,10 +17,11 @@ task:
     echo "OMP_PROC_BIND=TRUE" >> $CIRRUS_ENV
   configure_script: |
     if [ "$(uname -s)" = "FreeBSD" ]; then
-      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir -Dexamples=true -Dtests=true \
+      FC=gfortran12 CC=gcc12 CXX=g++12 meson setup builddir --buildtype=debug -Dexamples=true -Dtests=true \
                                                             -Dmetis64=true -Dlibblas=openblas -Dliblapack=openblas
     else
-      FC=gfortran-12 CC=gcc-12 CXX=g++-12 /opt/homebrew/opt/meson/bin/meson setup builddir -Dexamples=true -Dtests=true \
+      FC=gfortran-12 CC=gcc-12 CXX=g++-12 /opt/homebrew/opt/meson/bin/meson setup builddir --buildtype=debug \
+                                                               -Dexamples=true -Dtests=true \
                                                                -Dlibblas_path=/opt/homebrew/opt/openblas/lib \
                                                                -Dliblapack_path=/opt/homebrew/opt/openblas/lib \
                                                                -Dlibblas_include=/opt/homebrew/opt/openblas/include \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -142,7 +142,8 @@ jobs:
             METIS64="true"
           fi
           if [[ "${{matrix.compiler}}" == "gnu" ]]; then
-            meson setup builddir --prefix=$GITHUB_WORKSPACE/../meson -Dexamples=true -Dtests=true \
+            meson setup builddir --prefix=$GITHUB_WORKSPACE/../meson --buildtype=debug \
+                                 -Dexamples=true -Dtests=true \
                                  -Dlibmetis_path=$DEPS/deps/$LIBDIR -Dlibmetis=$LIBMETIS \
                                  -Dmetis64=$METIS64 -Dlibblas_path=$DEPS/deps/$LIBDIR \
                                  -Dlibblas=openblas -Dlibblas_include=../deps/include \
@@ -150,7 +151,8 @@ jobs:
                                  -Dlibhwloc_path=$DEPS/deps/$LIBDIR -Dlibhwloc=$LIBHWLOC \
                                  -Dlibhwloc_include=../deps/include
           else
-            meson setup builddir --prefix=$GITHUB_WORKSPACE/../meson -Dexamples=true -Dtests=true \
+            meson setup builddir --prefix=$GITHUB_WORKSPACE/../meson --buildtype=debug \
+                                 -Dexamples=true -Dtests=true \
                                  -Dlibmetis_path=$DEPS/deps/$LIBDIR -Dlibmetis=$LIBMETIS \
                                  -Dmetis64=$METIS64 -Dlibblas_path=$DEPS/deps/$LIBDIR \
                                  -Dlibblas=mkl_rt -Dlibblas_include=../deps/include \

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
 project(
   'SPRAL',
   'c', 'cpp', 'fortran',
-  version: '2023.10.4',
+  version: '2023.9.7',
   license: 'BSD-3',
   meson_version: '>= 0.63.0',
   default_options: [
-    'buildtype=debug',
+    'buildtype=release',
     'libdir=lib',
     'default_library=shared',
     'warning_level=0',


### PR DESCRIPTION
@jfowkes 
I forgot to compile SPRAL in `release` mode by default.
I modified CI scripts to still compile in `debug` mode.