### PR TITLE
Fix using constructor that is unavailable in C++11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
     'default_library=shared',
     'warning_level=0',
     'c_std=c99',
-    'cpp_std=c++17',
+    'cpp_std=c++11',
   ],
 )
 

--- a/src/ssids/cpu/kernels/ldlt_app.cxx
+++ b/src/ssids/cpu/kernels/ldlt_app.cxx
@@ -2382,7 +2382,7 @@ public:
 #ifdef PROFILE
          Profile::Task task_post("TA_LDLT_POST");
 #endif
-         std::vector<int, IntAlloc> failed_perm(n-num_elim, alloc);
+         std::vector<int, IntAlloc> failed_perm(n-num_elim, 0, alloc);
          for(int jblk=0, insert=0, fail_insert=0; jblk<nblk; jblk++) {
             cdata[jblk].move_back(
                   get_ncol(jblk, n, block_size), &perm[jblk*block_size],
@@ -2396,8 +2396,8 @@ public:
 
          // Extract failed entries of a
          int nfail = n-num_elim;
-         std::vector<T, TAlloc> failed_diag(nfail*n, alloc);
-         std::vector<T, TAlloc> failed_rect(nfail*(m-n), alloc);
+         std::vector<T, TAlloc> failed_diag(nfail*n, 0, alloc);
+         std::vector<T, TAlloc> failed_rect(nfail*(m-n), 0, alloc);
          for(int jblk=0, jfail=0, jinsert=0; jblk<nblk; ++jblk) {
             // Diagonal part
             for(int iblk=jblk, ifail=jfail, iinsert=jinsert; iblk<nblk; ++iblk) {


### PR DESCRIPTION
[According to cppreference.com](https://en.cppreference.com/w/cpp/container/vector/vector), the vector constructor `vector( size_type count, const Allocator& alloc = Allocator() )` without init value but with allocator that is used here was only introduced in C++14. Since we only compile with C++11, this was caught correctly by LLVM's libc++ (see #166). It only enables this constructor for C++14 and greater: https://github.com/llvm/llvm-project/blob/f39c38584eb762702a651e87e63162c9bc4842a3/libcxx/include/vector#L425-L427

Minimal example: https://godbolt.org/z/WqnWPdoK1 vs. https://godbolt.org/z/sq9srsb8P

GNUs stdlibc++ seems to just silently (and wrongfully) provide this constructor even on C++11, hiding this issue until now.

To fix this, provide the init value 0 explicitly to call the `vector( size_type count, const T& value = T(), const Allocator& alloc = Allocator() )` constructor that **is** provided by C++11. Fixes #166