### PR TITLE
Use C_INT64_T for long in GPU factor code

### DIFF
--- a/examples/Fortran/ssids.f90
+++ b/examples/Fortran/ssids.f90
@@ -3,7 +3,7 @@ program ssids_example
    use spral_ssids
    implicit none
 
-   integer, parameter :: long = selected_int_kind(16)
+   integer, parameter :: long = selected_int_kind(18)
 
    ! Derived types
    type (ssids_akeep)   :: akeep

--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -2045,9 +2045,9 @@ contains
     type(c_ptr), value, intent(in) :: c_rptr
     type(c_ptr), value, intent(in) :: c_sptr
     type(c_ptr), value, intent(in) :: c_asminf
-    integer(c_long), value, intent(in) :: pc_size
+    integer(c_int64_t), value, intent(in) :: pc_size
     ! type(c_ptr), value, intent(in) :: c_off_LDLT
-    integer(c_long), dimension(*), intent(in) :: off_LDLT
+    integer(c_int64_t), dimension(*), intent(in) :: off_LDLT
     type(c_ptr), value, intent(in) :: ptr_ccval ! GPU (*ptr_ccval) points to previous
       ! level's contribution blocks
     type(c_ptr), value, intent(in) :: c_gpu_contribs
@@ -2181,7 +2181,7 @@ contains
     type(c_ptr), value, intent(in) :: c_nodes
     type(c_ptr), value, intent(in) :: c_rptr
     type(c_ptr), value, intent(in) :: c_sptr
-    integer(c_long), dimension(*), intent(in) :: off_LDLT
+    integer(c_int64_t), dimension(*), intent(in) :: off_LDLT
     ! type(c_ptr), value, intent(in) :: c_off_LDLT
     type(c_ptr), value             :: ptr_levLDLT 
     type(c_ptr), value             :: c_gwork ! GPU workspace allocator 
@@ -2407,7 +2407,7 @@ contains
     type(c_ptr), value, intent(in) :: c_child_ptr 
     type(c_ptr), value, intent(in) :: c_child_list 
     ! type(c_ptr), value, intent(in) :: c_off_LDLT
-    integer(c_long), dimension(*) :: off_LDLT
+    integer(c_int64_t), dimension(*) :: off_LDLT
     type(c_ptr), value, intent(in) :: c_asminf ! Assembly info 
     type(c_ptr), value, intent(in) :: c_rptr
     type(c_ptr), value, intent(in) :: c_sptr
@@ -2550,7 +2550,7 @@ contains
     type(c_ptr), value, intent(in) :: c_lvllist
     type(c_ptr), value, intent(in) :: c_nodes
     integer(c_int), value :: ncb ! Number of nodes in level
-    integer(c_long), value :: level_size ! Number of (fully-summed) entries in level  
+    integer(c_int64_t), value :: level_size ! Number of (fully-summed) entries in level  
     type(c_ptr), value, intent(in) :: c_nptr
     type(c_ptr), value, intent(in) :: c_rptr
     type(c_ptr), value, intent(in) :: gpu_nlist ! nlist array on the GPU


### PR DESCRIPTION
Resolves #164 by making long in the GPU factor code 64bit always on every platform (I'm looking at you Windows).