### PR TITLE
Use malloc and variably-modified types for SSMFE C interface tests and examples

### DIFF
--- a/examples/C/ssmfe/laplace2d.h
+++ b/examples/C/ssmfe/laplace2d.h
@@ -4,17 +4,18 @@
 void apply_laplacian(
       int mx, int my, int nx, const double *x_ptr, double *Ax_ptr
       ) {
-   const double (*x)[my][mx] = (const double (*)[my][mx]) x_ptr;
-   double (*Ax)[my][mx] = (double (*)[my][mx]) Ax_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double (*x)[nx][my][mx] = (const double (*)[nx][my][mx]) x_ptr;
+   double (*Ax)[nx][my][mx] = (double (*)[nx][my][mx]) Ax_ptr;
    for(int k=0; k<nx; k++) {
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
-            double z = 4*x[k][j][i];
-            if( i > 0    ) z -= x[k][j][i-1];
-            if( j > 0    ) z -= x[k][j-1][i];
-            if( i < mx-1 ) z -= x[k][j][i+1];
-            if( j < my-1 ) z -= x[k][j+1][i];
-            Ax[k][j][i] = z;
+            double z = 4*(*x)[k][j][i];
+            if( i > 0    ) z -= (*x)[k][j][i-1];
+            if( j > 0    ) z -= (*x)[k][j-1][i];
+            if( i < mx-1 ) z -= (*x)[k][j][i+1];
+            if( j < my-1 ) z -= (*x)[k][j+1][i];
+            (*Ax)[k][j][i] = z;
          }
       }
    }
@@ -22,19 +23,19 @@ void apply_laplacian(
 
 /* Laplacian matrix for a rectangle of size nx x ny */
 void set_laplacian_matrix(
-      int nx, int ny, int lda, double a[nx*ny][lda]
+      int nx, int ny, int lda, double (*a)[nx*ny][lda]
       ) {
    for(int j=0; j<nx*ny; j++)
    for(int i=0; i<lda; i++)
-      a[j][i] = 0.0;
+      (*a)[j][i] = 0.0;
    for(int ix=0; ix<nx; ix++) {
       for(int iy=0; iy<ny; iy++) {
         int i = ix + iy*nx;
-        a[i][i] = 4;
-        if( ix >  0   ) a[i -  1][i] = -1;
-        if( ix < nx-1 ) a[i +  1][i] = -1;
-        if( iy > 0    ) a[i - nx][i] = -1;
-        if( iy < ny-1 ) a[i + nx][i] = -1;
+        (*a)[i][i] = 4;
+        if( ix >  0   ) (*a)[i -  1][i] = -1;
+        if( ix < nx-1 ) (*a)[i +  1][i] = -1;
+        if( iy > 0    ) (*a)[i - nx][i] = -1;
+        if( iy < ny-1 ) (*a)[i + nx][i] = -1;
       }
    }
 }
@@ -43,33 +44,34 @@ void set_laplacian_matrix(
 void apply_gauss_seidel_step(
       int mx, int my, int nx, const double *x_ptr, double *Tx_ptr
       ) {
-   const double (*x)[my][mx] = (const double (*)[my][mx]) x_ptr;
-   double (*Tx)[my][mx] = (double (*)[my][mx]) Tx_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double (*x)[nx][my][mx] = (const double (*)[nx][my][mx]) x_ptr;
+   double (*Tx)[nx][my][mx] = (double (*)[nx][my][mx]) Tx_ptr;
    for(int i=0; i<mx; i++)
       for(int j=0; j<my; j++)
          for(int k=0; k<nx; k++)
-            Tx[k][j][i] = x[k][j][i]/4;
+            (*Tx)[k][j][i] = (*x)[k][j][i]/4;
    for(int k=0; k<nx; k++) {
       /* forward update */
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
       /* backward update */
       for(int i=mx-1; i>=0; i--) {
          for(int j=my-1; j>=0; j--) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
    }

--- a/examples/C/ssmfe/ldltf.h
+++ b/examples/C/ssmfe/ldltf.h
@@ -13,13 +13,13 @@ int cwrap_dsytrs(char uplo, int n, int nrhs, double *a, int lda, int *ipiv, doub
 }
 
 /* Counts negative eigenvalues of factor D */
-int num_neg_D(int n, int ld, double LDLT[n][ld], int ipiv[n]) {
+int num_neg_D(int n, int ld, double (*LDLT)[n][ld], int *ipiv) {
    int nneg = 0;
    for(int i=0; i<n; ) {
-      double s = LDLT[i][i];
+      double s = (*LDLT)[i][i];
       if( ipiv[i] < 0 ) {
-         double t = LDLT[i][i+1];
-         double r = LDLT[i+1][i+1];
+         double t = (*LDLT)[i][i+1];
+         double r = (*LDLT)[i+1][i+1];
          if( s*r - t*t < 0.0 ) {
             nneg++;
          } else if ( s*r - t*t > 0.0 && s + r < 0.0 ){ 

--- a/examples/C/ssmfe/precond_expert.c
+++ b/examples/C/ssmfe/precond_expert.c
@@ -17,13 +17,13 @@ int main(void) {
 
    int state = SPRAL_RANDOM_INITIAL_SEED; /* PRNG state */
 
-   int ind[m];                    /* permutation index */
-   double lambda[n];              /* eigenvalues */
-   double X[n][n];                /* eigenvectors */
+   int *ind = malloc(m * sizeof(*ind));          /* permutation index */
+   double *lambda = malloc(n * sizeof(*lambda)); /* eigenvalues */
+   double (*X)[n][n] = malloc(sizeof(*X));       /* eigenvectors */
    /* Work arrays */
-   double rr[3][2*m][2*m];
-   double W[6][m][n];
-   double U[m][n];
+   double (*rr)[3][2*m][2*m] = malloc(sizeof(*rr));
+   double (*W)[6][m][n] = malloc(sizeof(*W));
+   double (*U)[m][n] = malloc(sizeof(*U));
 
    /* Derived types */
    struct spral_ssmfe_rcid rci;            /* reverse communication data */
@@ -42,92 +42,92 @@ int main(void) {
    /* Initialize W to lin indep vectors by randomizing */
    for(int i=0; i<n; i++)
    for(int j=0; j<m; j++)
-      W[0][j][i] = spral_random_real(&state, true);
+      (*W)[0][j][i] = spral_random_real(&state, true);
 
    int ncon = 0;   /* number of converged eigenpairs */
    rci.job = 0; keep = NULL;
    while(true) { /* reverse communication loop */
-      spral_ssmfe_expert_standard_double(&rci, nep, n, lambda, m, &rr[0][0][0],
+      spral_ssmfe_expert_standard_double(&rci, nep, n, lambda, m, &(*rr)[0][0][0],
          ind, &keep, &options, &inform);
       switch ( rci.job ) {
       case 1:
          apply_laplacian(
-            ngrid, ngrid, rci.nx, &W[rci.kx][rci.jx][0], &W[rci.ky][rci.jy][0]
+            ngrid, ngrid, rci.nx, &(*W)[rci.kx][rci.jx][0], &(*W)[rci.ky][rci.jy][0]
             );
          break;
       case 2:
          apply_gauss_seidel_step (
-            ngrid, ngrid, rci.nx, &W[rci.kx][rci.jx][0], &W[rci.ky][rci.jy][0]
+            ngrid, ngrid, rci.nx, &(*W)[rci.kx][rci.jx][0], &(*W)[rci.ky][rci.jy][0]
             );
          break;
       case 5:
          if ( rci.i < 0 ) continue;
          for(int k=0; k<rci.nx; k++) {
            int j = ncon + k;
-           cblas_dcopy( n, &W[0][rci.jx+k][0], 1, &X[j][0], 1 );
+           cblas_dcopy( n, &(*W)[0][rci.jx+k][0], 1, &(*X)[j][0], 1 );
          }
          ncon += rci.nx;
          break;
       case 11:
          if ( rci.i == 0 ) {
             if ( rci.kx != rci.ky || rci.jx > rci.jy ) {
-               cblas_dcopy(n*rci.nx, &W[rci.kx][rci.jx][0], 1, &W[rci.ky][rci.jy][0], 1);
+               cblas_dcopy(n*rci.nx, &(*W)[rci.kx][rci.jx][0], 1, &(*W)[rci.ky][rci.jy][0], 1);
             } else if ( rci.jx < rci.jy ) {
                for(int j=rci.nx-1; j>=0; j--)
-                  cblas_dcopy(n, &W[rci.kx][rci.jx+j][0], 1, &W[rci.ky][rci.jy+j][0], 1);
+                  cblas_dcopy(n, &(*W)[rci.kx][rci.jx+j][0], 1, &(*W)[rci.ky][rci.jy+j][0], 1);
             }
          } else {
             for(int i=0; i<n; i++) {
                for(int j=0; j<rci.nx; j++)
-                  U[j][i] = W[rci.kx][ind[j]][i];
+                  (*U)[j][i] = (*W)[rci.kx][ind[j]][i];
                for(int j=0; j<rci.nx; j++)
-                  W[rci.kx][j][i] = U[j][i];
+                  (*W)[rci.kx][j][i] = (*U)[j][i];
                if(rci.ky != rci.kx) {
                   for(int j=0; j<rci.nx; j++)
-                    U[j][i] = W[rci.ky][ind[j]][i];
+                    (*U)[j][i] = (*W)[rci.ky][ind[j]][i];
                   for(int j=0; j<rci.nx; j++)
-                    W[rci.ky][j][i] = U[j][i];
+                    (*W)[rci.ky][j][i] = (*U)[j][i];
                }
             }
          }
          break;
       case 12:
          for(int i=0; i<rci.nx; i++)
-           rr[rci.k][rci.j+i][rci.i+i] =
-             cblas_ddot(n, &W[rci.kx][rci.jx+i][0], 1, &W[rci.ky][rci.jy+i][0], 1);
+           (*rr)[rci.k][rci.j+i][rci.i+i] =
+             cblas_ddot(n, &(*W)[rci.kx][rci.jx+i][0], 1, &(*W)[rci.ky][rci.jy+i][0], 1);
          break;
       case 13:
          for(int i=0; i<rci.nx; i++) {
             if( rci.kx == rci.ky ) {
-               double s = cblas_dnrm2(n, &W[rci.kx][rci.jx+i][0], 1);
+               double s = cblas_dnrm2(n, &(*W)[rci.kx][rci.jx+i][0], 1);
                if( s > 0 )
-                  cblas_dscal(n, 1/s, &W[rci.kx][rci.jx+i][0], 1);
+                  cblas_dscal(n, 1/s, &(*W)[rci.kx][rci.jx+i][0], 1);
             } else {
                double s = sqrt(fabs(cblas_ddot(
-                  n, &W[rci.kx][rci.jx+i][0], 1, &W[rci.ky][rci.jy+i][0], 1)
+                  n, &(*W)[rci.kx][rci.jx+i][0], 1, &(*W)[rci.ky][rci.jy+i][0], 1)
                   ));
                if ( s > 0 ) {
-                  cblas_dscal(n, 1/s, &W[rci.kx][rci.jx+i][0], 1);
-                  cblas_dscal(n, 1/s, &W[rci.ky][rci.jy+i][0], 1);
+                  cblas_dscal(n, 1/s, &(*W)[rci.kx][rci.jx+i][0], 1);
+                  cblas_dscal(n, 1/s, &(*W)[rci.ky][rci.jy+i][0], 1);
                } else {
                   for(int j=0; j<n; j++)
-                     W[rci.ky][rci.jy+i][j] = 0.0;
+                     (*W)[rci.ky][rci.jy+i][j] = 0.0;
                }
             }
          }
          break;
       case 14:
          for(int i=0; i<rci.nx; i++) {
-           double s = -rr[rci.k][rci.j+i][rci.i+i];
-           cblas_daxpy(n, s, &W[rci.kx][rci.jx+i][0], 1, &W[rci.ky][rci.jy+i][0], 1);
+           double s = -(*rr)[rci.k][rci.j+i][rci.i+i];
+           cblas_daxpy(n, s, &(*W)[rci.kx][rci.jx+i][0], 1, &(*W)[rci.ky][rci.jy+i][0], 1);
          }
          break;
       case 15:
          if ( rci.nx > 0 && rci.ny > 0 )
             cblas_dgemm(
                CblasColMajor, CblasTrans, CblasNoTrans, rci.nx, rci.ny, n,
-               rci.alpha, &W[rci.kx][rci.jx][0], n, &W[rci.ky][rci.jy][0], n,
-               rci.beta, &rr[rci.k][rci.j][rci.i], 2*m
+               rci.alpha, &(*W)[rci.kx][rci.jx][0], n, &(*W)[rci.ky][rci.jy][0], n,
+               rci.beta, &(*rr)[rci.k][rci.j][rci.i], 2*m
                );
          break;
       case 16: // Fall through to 17
@@ -137,21 +137,21 @@ int main(void) {
             if( rci.job == 17 ) continue;
             if( rci.beta == 1.0 ) continue;
             for(int j=rci.jy; j<rci.jy+rci.ny; j++)
-               cblas_dscal(n, rci.beta, &W[rci.ky][j][0], 1);
+               cblas_dscal(n, rci.beta, &(*W)[rci.ky][j][0], 1);
             continue;
          }
          if( rci.job == 17 ) {
             cblas_dgemm(
                CblasColMajor, CblasNoTrans, CblasNoTrans, n, rci.ny, rci.nx,
-               1.0, &W[rci.kx][rci.jx][0], n, &rr[rci.k][rci.j][rci.i], 2*m,
-               0.0, &W[rci.ky][rci.jy][0], n
+               1.0, &(*W)[rci.kx][rci.jx][0], n, &(*rr)[rci.k][rci.j][rci.i], 2*m,
+               0.0, &(*W)[rci.ky][rci.jy][0], n
                );
-            cblas_dcopy(n*rci.ny, &W[rci.ky][rci.jy][0], 1, &W[rci.kx][rci.jx][0], 1);
+            cblas_dcopy(n*rci.ny, &(*W)[rci.ky][rci.jy][0], 1, &(*W)[rci.kx][rci.jx][0], 1);
          } else {
             cblas_dgemm(
                CblasColMajor, CblasNoTrans, CblasNoTrans, n, rci.ny, rci.nx,
-               rci.alpha, &W[rci.kx][rci.jx][0], n, &rr[rci.k][rci.j][rci.i],
-               2*m, rci.beta, &W[rci.ky][rci.jy][0], n
+               rci.alpha, &(*W)[rci.kx][rci.jx][0], n, &(*rr)[rci.k][rci.j][rci.i],
+               2*m, rci.beta, &(*W)[rci.ky][rci.jy][0], n
                );
          }
          break;
@@ -160,11 +160,11 @@ int main(void) {
          if( ncon > 0 ) {
             cblas_dgemm(
                CblasColMajor, CblasTrans, CblasNoTrans, ncon, rci.nx, n,
-               1.0, &X[0][0], n, &W[rci.ky][rci.jy][0], n, 0.0, &U[0][0], n
+               1.0, &(*X)[0][0], n, &(*W)[rci.ky][rci.jy][0], n, 0.0, &(*U)[0][0], n
                );
             cblas_dgemm(
                CblasColMajor, CblasNoTrans, CblasNoTrans, n, rci.nx, ncon,
-               -1.0, &X[0][0], n, &U[0][0], n, 1.0, &W[rci.kx][rci.jx][0], n
+               -1.0, &(*X)[0][0], n, &(*U)[0][0], n, 1.0, &(*W)[rci.kx][rci.jx][0], n
                );
          }
          break;
@@ -173,7 +173,7 @@ int main(void) {
             if( rci.jx > 1 ) {
                for(int j=0; j<rci.jx; j++)
                for(int i=0; i<n; i++)
-                  W[0][j][i] = spral_random_real(&state, true);
+                  (*W)[0][j][i] = spral_random_real(&state, true);
             }
          }
          break;
@@ -187,6 +187,12 @@ finished:
    for(int i=0; i<ncon; i++)
       printf(" lambda[%1d] = %13.7e\n", i, lambda[i]);
    spral_ssmfe_expert_free(&keep, &inform);
+   free(ind);
+   free(lambda);
+   free(X);
+   free(rr);
+   free(W);
+   free(U);
 
    /* Success */
    return 0;

--- a/examples/C/ssmfe/precond_ssmfe.c
+++ b/examples/C/ssmfe/precond_ssmfe.c
@@ -14,8 +14,8 @@ int main(void) {
    const int n   = m*m;    /* problem size */
    const int nep = 5;      /* eigenpairs wanted */
 
-   double lambda[2*nep];                  /* eigenvalues */
-   double X[2*nep][n];                    /* eigenvectors */
+   double *lambda = malloc(2*nep * sizeof(*lambda)); /* eigenvalues */
+   double (*X)[2*nep][n] = malloc(sizeof(*X));       /* eigenvectors */
    struct spral_ssmfe_rcid rci;           /* reverse communication data */
    struct spral_ssmfe_options options;    /* options */
    void *keep;                            /* private data */
@@ -29,7 +29,7 @@ int main(void) {
 
    rci.job = 0; keep = NULL;
    while(true) { /* reverse communication loop */
-      spral_ssmfe_standard_double(&rci, nep, 2*nep, lambda, n, &X[0][0], n,
+      spral_ssmfe_standard_double(&rci, nep, 2*nep, lambda, n, &(*X)[0][0], n,
          &keep, &options, &inform);
       switch ( rci.job ) {
       case 1:
@@ -47,6 +47,8 @@ finished:
    for(int i=0; i<inform.left; i++)
       printf(" lambda[%1d] = %13.7e\n", i, lambda[i]);
    spral_ssmfe_free_double(&keep, &inform);
+   free(lambda);
+   free(X);
 
    /* Success */
    return 0;

--- a/examples/C/ssmfe/shift_invert.c
+++ b/examples/C/ssmfe/shift_invert.c
@@ -16,12 +16,12 @@ int main(void) {
    const int n = nx*ny;       /* problem size */
    const double sigma = 1.0;  /* shift */
 
-   int ipiv[n];               /* LDLT pivot index */
-   double lambda[n];          /* eigenvalues */
-   double X[n][n];            /* eigenvectors */
-   double A[n][n];            /* matrix */
-   double LDLT[n][n];         /* factors */
-   double work[n][n];         /* work array for dsytrf */
+   int *ipiv = malloc(n * sizeof(*ipiv));        /* LDLT pivot index */
+   double *lambda = malloc(n * sizeof(*lambda)); /* eigenvalues */
+   double (*X)[n][n] = malloc(sizeof(*X));       /* eigenvectors */
+   double (*A)[n][n] = malloc(sizeof(*A));       /* matrix */
+   double (*LDLT)[n][n] = malloc(sizeof(*LDLT)); /* factors */
+   double (*work)[n][n] = malloc(sizeof(*work)); /* work array for dsytrf */
    struct spral_ssmfe_options options;    /* eigensolver options */
    struct spral_ssmfe_inform inform;      /* information */
    struct spral_ssmfe_rcid rci;           /* reverse communication data */
@@ -34,9 +34,9 @@ int main(void) {
    set_laplacian_matrix(nx, ny, n, A);
    for(int j=0; j<n; j++)
    for(int i=0; i<n; i++)
-      LDLT[j][i] = (i==j) ? A[j][i] - sigma
-                          : A[j][i];
-   cwrap_dsytrf('L', n, &LDLT[0][0], n, ipiv, &work[0][0], n*n);
+      (*LDLT)[j][i] = (i==j) ? (*A)[j][i] - sigma
+                             : (*A)[j][i];
+   cwrap_dsytrf('L', n, &(*LDLT)[0][0], n, ipiv, &(*work)[0][0], n*n);
 
    /* Main loop */
    int left = num_neg_D(n, n, LDLT, ipiv);   /* all evalues to left of sigma */
@@ -44,18 +44,18 @@ int main(void) {
    rci.job = 0; keep = NULL;
    while(true) {
       spral_ssmfe_standard_shift_double(&rci, sigma, left, right, n, lambda,
-            n, &X[0][0], n, &keep, &options, &inform);
+            n, &(*X)[0][0], n, &keep, &options, &inform);
       switch( rci.job ) {
       case 1:
          cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, rci.nx, n,
-            1.0, &A[0][0], n, rci.x, n, 0.0, rci.y, n);
+            1.0, &(*A)[0][0], n, rci.x, n, 0.0, rci.y, n);
          break;
       case 2:
          // No preconditioning
          break;
       case 9:
          cblas_dcopy(n*rci.nx, rci.x, 1, rci.y, 1);
-         cwrap_dsytrs('L', n, rci.nx, &LDLT[0][0], n, ipiv, rci.y, n);
+         cwrap_dsytrs('L', n, rci.nx, &(*LDLT)[0][0], n, ipiv, rci.y, n);
          break;
       default:
          goto finished;
@@ -66,6 +66,12 @@ finished:
    for(int i=0; i<inform.left+inform.right; i++)
       printf(" lambda[%1d] = %13.7e\n", i, lambda[i]);
    spral_ssmfe_free_double(&keep, &inform);
+   free(ipiv);
+   free(lambda);
+   free(X);
+   free(A);
+   free(LDLT);
+   free(work);
 
    /* Success */
    return 0;

--- a/tests/ssmfe/laplace2d.h
+++ b/tests/ssmfe/laplace2d.h
@@ -4,17 +4,18 @@
 void apply_laplacian(
       int mx, int my, int nx, const double *x_ptr, double *Ax_ptr
       ) {
-   const double (*x)[my][mx] = (const double (*)[my][mx]) x_ptr;
-   double (*Ax)[my][mx] = (double (*)[my][mx]) Ax_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double (*x)[nx][my][mx] = (const double (*)[nx][my][mx]) x_ptr;
+   double (*Ax)[nx][my][mx] = (double (*)[nx][my][mx]) Ax_ptr;
    for(int k=0; k<nx; k++) {
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
-            double z = 4*x[k][j][i];
-            if( i > 0    ) z -= x[k][j][i-1];
-            if( j > 0    ) z -= x[k][j-1][i];
-            if( i < mx-1 ) z -= x[k][j][i+1];
-            if( j < my-1 ) z -= x[k][j+1][i];
-            Ax[k][j][i] = z;
+            double z = 4*(*x)[k][j][i];
+            if( i > 0    ) z -= (*x)[k][j][i-1];
+            if( j > 0    ) z -= (*x)[k][j-1][i];
+            if( i < mx-1 ) z -= (*x)[k][j][i+1];
+            if( j < my-1 ) z -= (*x)[k][j+1][i];
+            (*Ax)[k][j][i] = z;
          }
       }
    }
@@ -24,17 +25,18 @@ void apply_laplacian_z(
       int mx, int my, int nx, 
       const double complex *x_ptr, double complex *Ax_ptr
       ) {
-   const double complex (*x)[my][mx] = (const double complex (*)[my][mx]) x_ptr;
-   double complex (*Ax)[my][mx] = (double complex (*)[my][mx]) Ax_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double complex (*x)[nx][my][mx] = (const double complex (*)[nx][my][mx]) x_ptr;
+   double complex (*Ax)[nx][my][mx] = (double complex (*)[nx][my][mx]) Ax_ptr;
    for(int k=0; k<nx; k++) {
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
-            double complex z = 4*x[k][j][i];
-            if( i > 0    ) z -= x[k][j][i-1];
-            if( j > 0    ) z -= x[k][j-1][i];
-            if( i < mx-1 ) z -= x[k][j][i+1];
-            if( j < my-1 ) z -= x[k][j+1][i];
-            Ax[k][j][i] = z;
+            double complex z = 4*(*x)[k][j][i];
+            if( i > 0    ) z -= (*x)[k][j][i-1];
+            if( j > 0    ) z -= (*x)[k][j-1][i];
+            if( i < mx-1 ) z -= (*x)[k][j][i+1];
+            if( j < my-1 ) z -= (*x)[k][j+1][i];
+            (*Ax)[k][j][i] = z;
          }
       }
    }
@@ -42,37 +44,37 @@ void apply_laplacian_z(
 
 /* Laplacian matrix for a rectangle of size nx x ny */
 void set_laplacian_matrix(
-      int nx, int ny, int lda, double a[nx*ny][lda]
+      int nx, int ny, int lda, double (*a)[nx*ny][lda]
       ) {
    for(int j=0; j<nx*ny; j++)
    for(int i=0; i<lda; i++)
-      a[j][i] = 0.0;
+      (*a)[j][i] = 0.0;
    for(int ix=0; ix<nx; ix++) {
       for(int iy=0; iy<ny; iy++) {
         int i = ix + iy*nx;
-        a[i][i] = 4;
-        if( ix >  0   ) a[i -  1][i] = -1;
-        if( ix < nx-1 ) a[i +  1][i] = -1;
-        if( iy > 0    ) a[i - nx][i] = -1;
-        if( iy < ny-1 ) a[i + nx][i] = -1;
+        (*a)[i][i] = 4;
+        if( ix >  0   ) (*a)[i -  1][i] = -1;
+        if( ix < nx-1 ) (*a)[i +  1][i] = -1;
+        if( iy > 0    ) (*a)[i - nx][i] = -1;
+        if( iy < ny-1 ) (*a)[i + nx][i] = -1;
       }
    }
 }
 
 void set_laplacian_matrix_z(
-      int nx, int ny, int lda, double complex a[nx*ny][lda]
+      int nx, int ny, int lda, double complex (*a)[nx*ny][lda]
       ) {
    for(int j=0; j<nx*ny; j++)
    for(int i=0; i<lda; i++)
-      a[j][i] = 0.0;
+      (*a)[j][i] = 0.0;
    for(int ix=0; ix<nx; ix++) {
       for(int iy=0; iy<ny; iy++) {
         int i = ix + iy*nx;
-        a[i][i] = 4;
-        if( ix >  0   ) a[i -  1][i] = -1;
-        if( ix < nx-1 ) a[i +  1][i] = -1;
-        if( iy > 0    ) a[i - nx][i] = -1;
-        if( iy < ny-1 ) a[i + nx][i] = -1;
+        (*a)[i][i] = 4;
+        if( ix >  0   ) (*a)[i -  1][i] = -1;
+        if( ix < nx-1 ) (*a)[i +  1][i] = -1;
+        if( iy > 0    ) (*a)[i - nx][i] = -1;
+        if( iy < ny-1 ) (*a)[i + nx][i] = -1;
       }
    }
 }
@@ -81,33 +83,34 @@ void set_laplacian_matrix_z(
 void apply_gauss_seidel_step(
       int mx, int my, int nx, const double *x_ptr, double *Tx_ptr
       ) {
-   const double (*x)[my][mx] = (const double (*)[my][mx]) x_ptr;
-   double (*Tx)[my][mx] = (double (*)[my][mx]) Tx_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double (*x)[nx][my][mx] = (const double (*)[nx][my][mx]) x_ptr;
+   double (*Tx)[nx][my][mx] = (double (*)[nx][my][mx]) Tx_ptr;
    for(int i=0; i<mx; i++)
       for(int j=0; j<my; j++)
          for(int k=0; k<nx; k++)
-            Tx[k][j][i] = x[k][j][i]/4;
+            (*Tx)[k][j][i] = (*x)[k][j][i]/4;
    for(int k=0; k<nx; k++) {
       /* forward update */
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
       /* backward update */
       for(int i=mx-1; i>=0; i--) {
          for(int j=my-1; j>=0; j--) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
    }
@@ -117,33 +120,34 @@ void apply_gauss_seidel_step_z(
       int mx, int my, int nx, 
       const double complex *x_ptr, double complex *Tx_ptr
       ) {
-   const double complex (*x)[my][mx] = (const double complex (*)[my][mx]) x_ptr;
-   double complex (*Tx)[my][mx] = (double complex (*)[my][mx]) Tx_ptr;
+   /* Use "variable-modified types" to simplify matrix indexing */
+   const double complex (*x)[nx][my][mx] = (const double complex (*)[nx][my][mx]) x_ptr;
+   double complex (*Tx)[nx][my][mx] = (double complex (*)[nx][my][mx]) Tx_ptr;
    for(int i=0; i<mx; i++)
       for(int j=0; j<my; j++)
          for(int k=0; k<nx; k++)
-            Tx[k][j][i] = x[k][j][i]/4;
+            (*Tx)[k][j][i] = (*x)[k][j][i]/4;
    for(int k=0; k<nx; k++) {
       /* forward update */
       for(int i=0; i<mx; i++) {
          for(int j=0; j<my; j++) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
       /* backward update */
       for(int i=mx-1; i>=0; i--) {
          for(int j=my-1; j>=0; j--) {
             double z = 0.0;
-            if( i > 0    ) z += Tx[k][j][i-1];
-            if( j > 0    ) z += Tx[k][j-1][i];
-            if( i < mx-1 ) z += Tx[k][j][i+1];
-            if( j < my-1 ) z += Tx[k][j+1][i];
-            Tx[k][j][i] = (Tx[k][j][i] + z/4)/4;
+            if( i > 0    ) z += (*Tx)[k][j][i-1];
+            if( j > 0    ) z += (*Tx)[k][j-1][i];
+            if( i < mx-1 ) z += (*Tx)[k][j][i+1];
+            if( j < my-1 ) z += (*Tx)[k][j+1][i];
+            (*Tx)[k][j][i] = ((*Tx)[k][j][i] + z/4)/4;
          }
       }
    }

--- a/tests/ssmfe/ldltf.h
+++ b/tests/ssmfe/ldltf.h
@@ -13,13 +13,13 @@ int cwrap_dsytrs(char uplo, int n, int nrhs, double *a, int lda, int *ipiv, doub
 }
 
 /* Counts negative eigenvalues of factor D */
-int num_neg_D(int n, int ld, double LDLT[n][ld], int ipiv[n]) {
+int num_neg_D(int n, int ld, double (*LDLT)[n][ld], int *ipiv) {
    int nneg = 0;
    for(int i=0; i<n; ) {
-      double s = LDLT[i][i];
+      double s = (*LDLT)[i][i];
       if( ipiv[i] < 0 ) {
-         double t = LDLT[i][i+1];
-         double r = LDLT[i+1][i+1];
+         double t = (*LDLT)[i][i+1];
+         double r = (*LDLT)[i+1][i+1];
          if( s*r - t*t < 0.0 ) {
             nneg++;
          } else if ( s*r - t*t > 0.0 && s + r < 0.0 ){ 
@@ -34,13 +34,13 @@ int num_neg_D(int n, int ld, double LDLT[n][ld], int ipiv[n]) {
    return nneg;
 }
 
-int num_neg_Dz(int n, int ld, double complex LDLT[n][ld], int ipiv[n]) {
+int num_neg_Dz(int n, int ld, double complex (*LDLT)[n][ld], int *ipiv) {
    int nneg = 0;
    for(int i=0; i<n; ) {
-      double s = LDLT[i][i];
+      double s = (*LDLT)[i][i];
       if( ipiv[i] < 0 ) {
-         double t = fabs(LDLT[i][i+1]);
-         double r = LDLT[i+1][i+1];
+         double t = fabs((*LDLT)[i][i+1]);
+         double r = (*LDLT)[i+1][i+1];
          if( s*r - t*t < 0.0 ) {
             nneg++;
          } else if ( s*r - t*t > 0.0 && s + r < 0.0 ){ 


### PR DESCRIPTION
On Windows, the tests ran out of stack space due to the many variable-length arrays on the stack (as found out in #162). So allocating on the heap with `malloc` instead. Fixes #156 

To still be able to do all the matrix indexing, we use variably-modified types (also described in #162). That requires dereferencing to be added in many places and makes the syntax a bit unfamiliar, but it does avoid having to do the indexing manually. So to me this solution would be preferrable.

If the solution using manual indexing is preferred (https://github.com/mjacobse/spral/commit/b61dc5a6c2348647fefad0d1c9e93f1eaf35e453), let me know and I can create a pull request with that instead.
