### PR TITLE
Fix uninitialised ptr compiler warning

### DIFF
--- a/src/ssids/cpu/BuddyAllocator.hxx
+++ b/src/ssids/cpu/BuddyAllocator.hxx
@@ -313,7 +313,7 @@ public:
    void* allocate(std::size_t sz) {
       // Try allocating in existing pages
       spral::omp::AcquiredLock scopeLock(lock_);
-      void* ptr;
+      void* ptr = nullptr;
       for(auto& page: pages_) {
          ptr = page.allocate(sz);
          if(ptr) break; // allocation suceeded


### PR DESCRIPTION
As reported by @nimgould compilers currently raise a warning for this section of `BuddyAllocator.hxx`:
```C++
   void* allocate(std::size_t sz) {
      // Try allocating in existing pages
      spral::omp::AcquiredLock scopeLock(lock_);
      void* ptr;
      for(auto& page: pages_) {
         ptr = page.allocate(sz);
         if(ptr) break; // allocation suceeded
      }
      if(!ptr) {
         // Failed to alloc on existing page: make a bigger page and use it
```
that the pointer may be used uninitialised:
```
warning: ‘ptr’ may be used uninitialized in this function
|       if(!ptr) {
```
This PR explicitly initialises the pointer to nullptr rather than expecting the compiler to do this.