### PR TITLE
Improve unit tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -195,6 +195,7 @@ endif
 if build_tests
 
   fortran_tests_folder = 'tests/Fortran'
+  env = ['OMP_CANCELLATION=true', 'OMP_PROC_BIND=true']
 
   foreach test: spral_tests
     name = test[0]
@@ -202,7 +203,7 @@ if build_tests
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'fortran',
                     include_directories: libspral_include, install : false, install_dir : fortran_tests_folder),
-         timeout : 300, is_parallel : false)
+         timeout : 300, is_parallel : false, env: env)
   endforeach
 
   c_tests_folder = 'tests/C'
@@ -213,7 +214,7 @@ if build_tests
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'c',
                     include_directories : libspral_include, install : false, install_dir : c_tests_folder),
-         timeout : 300, is_parallel : false)
+         timeout : 300, is_parallel : false, env: env)
   endforeach
 
   cpp_tests_folder = 'tests/C++'
@@ -224,7 +225,7 @@ if build_tests
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'cpp',
                     include_directories : libspral_include, install : false, install_dir : cpp_tests_folder),
-         timeout : 300, is_parallel : false)
+         timeout : 300, is_parallel : false, env: env)
   endforeach
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -201,7 +201,7 @@ if build_tests
     file = test[1]
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'fortran',
-                    include_directories: libspral_include, install : true, install_dir : fortran_tests_folder),
+                    include_directories: libspral_include, install : false, install_dir : fortran_tests_folder),
          timeout : 300, is_parallel : false)
   endforeach
 
@@ -212,7 +212,7 @@ if build_tests
     file = test[1]
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'c',
-                    include_directories : libspral_include, install : true, install_dir : c_tests_folder),
+                    include_directories : libspral_include, install : false, install_dir : c_tests_folder),
          timeout : 300, is_parallel : false)
   endforeach
 
@@ -223,7 +223,7 @@ if build_tests
     file = test[1]
     test(name,
          executable(name, file, link_with : libspral, dependencies : libspral_deps, link_language : 'cpp',
-                    include_directories : libspral_include, install : true, install_dir : cpp_tests_folder),
+                    include_directories : libspral_include, install : false, install_dir : cpp_tests_folder),
          timeout : 300, is_parallel : false)
   endforeach
 endif


### PR DESCRIPTION
There are as of currently some inconveniences with regards to the built-in unit tests:

- First, the tests  are installed, which goes against conventions: Either people help to develop the package using the existing source, or they want to use the library / drivers after install. In either case, the tests are not required to be installed.
- Second, the unit tests don't pass unless certain OMP-related environment variables are set. If these variables are set via meson, then this problem disappears and the tests always pass.