### PR TITLE
Fix documentation of norm equilibration scaling

### DIFF
--- a/docs/C/scaling.rst
+++ b/docs/C/scaling.rst
@@ -328,7 +328,7 @@ Routines
 
 .. c:function:: void spral_scaling_equilib_sym(int n, const int *ptr, const int *row, const double *val, double *scaling, const struct spral_scaling_equilib_options *options, struct spral_scaling_equilib_inform *inform)
 
-   Find a matching-based symmetric scaling using the norm-equilibration
+   Find a symmetric scaling using the norm-equilibration
    algorithm.
 
    The scaled matrix is such that the infinity norm of each row and column are
@@ -348,7 +348,7 @@ Routines
 
 .. c:function:: void spral_scaling_equilib_unsym(int m, int n, const int *ptr, const int *row, const double *val, double *rscaling, double *cscaling, const struct spral_scaling_equilib_options *options, struct spral_scaling_equilib_inform *inform)
 
-   Find a matching-based unsymmetric scaling using the norm-equilibration
+   Find an unsymmetric scaling using the norm-equilibration
    algorithm.
 
    The scaled matrix is such that the infinity norm of each row and column are

--- a/docs/Fortran/scaling.rst
+++ b/docs/Fortran/scaling.rst
@@ -260,7 +260,7 @@ Routines
 
 .. f:subroutine:: equilib_scale_sym(n, ptr, row, val, scaling, options, inform)
 
-   Find a matching-based symmetric scaling using the norm-equilibration algorithm.
+   Find a symmetric scaling using the norm-equilibration algorithm.
 
    The scaled matrix is such that the infinity norm of each row and column are
    equal to :math:`1.0`.
@@ -275,7 +275,7 @@ Routines
 
 .. f:subroutine:: equilib_scale_unsym(m, n, ptr, row, val, rscaling, cscaling, options, inform)
 
-   Find a matching-based unsymmetric scaling using the norm-equilibration algorithm.
+   Find an unsymmetric scaling using the norm-equilibration algorithm.
 
    The scaled matrix is such that the infinity norm of each row and column are
    equal to :math:`1.0`.

--- a/examples/C/scaling/equilib_unsym.c
+++ b/examples/C/scaling/equilib_unsym.c
@@ -33,7 +33,7 @@ int main(void) {
       exit(1);
    }
 
-   /* Print scaling and matching */
+   /* Print scaling */
    printf("Row Scaling: ");
    for(int i=0; i<m; i++) printf(" %10.2le", rscaling[i]);
    printf("\nCol Scaling: ");

--- a/examples/Fortran/scaling/equilib_sym.f90
+++ b/examples/Fortran/scaling/equilib_sym.f90
@@ -41,7 +41,7 @@ program equilib_scale_sym_example
       stop
    endif
 
-   ! Print scaling and matching
+   ! Print scaling
    write(*,"(a,10es10.2)") 'Scaling: ', scaling(1:n)
 
    ! Calculate scaled matrix and print it

--- a/examples/Fortran/scaling/equilib_unsym.f90
+++ b/examples/Fortran/scaling/equilib_unsym.f90
@@ -42,7 +42,7 @@ program equilib_scale_unsym_example
       stop
    endif
 
-   ! Print scaling and matching
+   ! Print scaling
    write(*,"(a,10es10.2)") 'Row Scaling: ', rscaling(1:m)
    write(*,"(a,10es10.2)") 'Col Scaling: ', cscaling(1:n)
 


### PR DESCRIPTION
Norm equilibration scaling is not matching-based. Probably copy-paste errors.