### PR TITLE
Fix length of unsymmetric matching in doc and examples

### DIFF
--- a/docs/Fortran/scaling.rst
+++ b/docs/Fortran/scaling.rst
@@ -79,7 +79,7 @@ Routines
    :p real cscaling(n) [out]: returns column scaling found by routine
    :p auction_options options [in]: controls behaviour of routine
    :p auction_inform inform [out]: returns information on execution of routine
-   :o integer match(n) [out]: returns matching found by routine. Row i is
+   :o integer match(m) [out]: returns matching found by routine. Row i is
       matched to column match(i), or is unmatched if match(i)=0.
 
 Data-types
@@ -417,7 +417,7 @@ Routines
    :p real cscaling(n) [out]: returns column scaling found by routine.
    :p hungarian_options options [in]: controls behaviour of routine.
    :p hungarian_inform inform [out]: returns information on execution of routine.
-   :o integer match(n) [out]: returns matching found by routine. Row i is
+   :o integer match(m) [out]: returns matching found by routine. Row i is
       matched to column match(i), or is unmatched if match(i)=0.
 
 Data-types

--- a/examples/C/scaling/auction_unsym.c
+++ b/examples/C/scaling/auction_unsym.c
@@ -36,7 +36,7 @@ int main(void) {
 
    /* Print scaling and matching */
    printf("Matching:");
-   for(int i=0; i<n; i++) printf(" %10d", match[i]);
+   for(int i=0; i<m; i++) printf(" %10d", match[i]);
    printf("\nRow Scaling: ");
    for(int i=0; i<m; i++) printf(" %10.2le", rscaling[i]);
    printf("\nCol Scaling: ");

--- a/examples/C/scaling/hungarian_unsym.c
+++ b/examples/C/scaling/hungarian_unsym.c
@@ -36,7 +36,7 @@ int main(void) {
 
    /* Print scaling and matching */
    printf("Matching:");
-   for(int i=0; i<n; i++) printf(" %10d", match[i]);
+   for(int i=0; i<m; i++) printf(" %10d", match[i]);
    printf("\nRow Scaling: ");
    for(int i=0; i<m; i++) printf(" %10.2le", rscaling[i]);
    printf("\nCol Scaling: ");


### PR DESCRIPTION
Probably copy-paste error from symmetric cases. Fixes #207