### PR TITLE
Fix check in unsymmetric scaling test

### DIFF
--- a/tests/scaling.f90
+++ b/tests/scaling.f90
@@ -299,7 +299,7 @@ subroutine test_auction_unsym_random
          errors = errors + 1
          cycle prblm_loop
       endif
-      if(any(cnt(1:a%m).gt.1)) then
+      if(any(cnt(1:a%n).gt.1)) then
          write(*, "(a)") "Mismatched row"
          errors = errors + 1
          cycle prblm_loop
@@ -809,7 +809,7 @@ subroutine test_hungarian_unsym_random
          errors = errors + 1
          cycle prblm_loop
       endif
-      if(any(cnt(1:a%m).gt.1)) then
+      if(any(cnt(1:a%n).gt.1)) then
          write(*, "(a)") "Mismatched row"
          errors = errors + 1
          cycle prblm_loop


### PR DESCRIPTION
`cnt` counts column-wise, so should be checked up to the number of columns `a%n`, not the number of rows `a%m`. Noticed when doing tests for #207 by allocating the exact sizes for each randomly generated matrix rather than the oversized maximum sizes. Perhaps that would be a good general improvement for the tests, even with #207 already fixed? 