### PR TITLE
Fix extra space after goto

### DIFF
--- a/src/ssids/gpu/factor.f90
+++ b/src/ssids/gpu/factor.f90
@@ -97,7 +97,7 @@ contains
     ! Determine level structure
     allocate(stream_data%lvllist(nnodes), &
          stream_data%lvlptr(nnodes + 1), stat=stats%st)
-    if (stats%st .ne. 0) goto  100
+    if (stats%st .ne. 0) goto 100
     call assign_nodes_to_levels(nnodes, sparent, gpu_contribs, &
          stream_data%num_levels, stream_data%lvlptr, stream_data%lvllist, stats%st)
     if (stats%st .ne. 0) goto 100


### PR DESCRIPTION
Fix extra space after goto that is seemingly causing the latest nvfortran to choke with an internal compiler error.