### PR TITLE
Add simple topology option to SSIDS C interface

### DIFF
--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -67,6 +67,11 @@ void spral_ssids_analyse(bool check, int n, int *order, const int64_t *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
+void spral_ssids_analyse_topology(bool check, int n, int *order, const int64_t *ptr,
+      const int *row, const double *val, void **akeep,
+      const struct spral_ssids_options *options,
+      struct spral_ssids_inform *inform,
+      int nproc, int ngpu, const int *gpus);
 void spral_ssids_analyse_ptr32(bool check, int n, int *order, const int *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,


### PR DESCRIPTION
This draft PR adds a simple topology option to the C interface of `ssids_analyse()`.

@LiuZhexuan please test this PR and let us know if it works for you. 

If this works we'll see if we can extend this so that a full topology can be defined in C.