### PR TITLE
Fix hwloc CPU detection

### DIFF
--- a/src/hw_topology/guess_topology.cxx
+++ b/src/hw_topology/guess_topology.cxx
@@ -42,8 +42,9 @@ void spral_hw_topology_guess(int* nregions, NumaRegion** regions) {
    *regions = new NumaRegion[*nregions];
    for(int i=0; i<*nregions; ++i) {
       NumaRegion& region = (*regions)[i];
-      region.nproc = topology.count_cores(numa_nodes[i]);
-      auto gpus = topology.get_gpus(numa_nodes[i]);
+      auto parent = numa_nodes[i]->parent;
+      region.nproc = topology.count_cores(parent);
+      auto gpus = topology.get_gpus(parent);
       region.ngpu = gpus.size();
       region.gpus = (region.ngpu > 0) ? new int[region.ngpu] : nullptr;
       for(int i=0; i<region.ngpu; ++i)

--- a/src/hw_topology/guess_topology.cxx
+++ b/src/hw_topology/guess_topology.cxx
@@ -42,9 +42,14 @@ void spral_hw_topology_guess(int* nregions, NumaRegion** regions) {
    *regions = new NumaRegion[*nregions];
    for(int i=0; i<*nregions; ++i) {
       NumaRegion& region = (*regions)[i];
+#if HWLOC_API_VERSION >= 0x20000
       auto parent = numa_nodes[i]->parent;
       region.nproc = topology.count_cores(parent);
       auto gpus = topology.get_gpus(parent);
+#else /* HWLOC_API_VERSION */
+      region.nproc = topology.count_cores(numa_nodes[i]);
+      auto gpus = topology.get_gpus(numa_nodes[i]);
+#endif /* HWLOC_API_VERSION */
       region.ngpu = gpus.size();
       region.gpus = (region.ngpu > 0) ? new int[region.ngpu] : nullptr;
       for(int i=0; i<region.ngpu; ++i)


### PR DESCRIPTION
> In hwloc v1.x, NUMA nodes were inside the tree, for instance Packages contained 2 NUMA nodes which contained a L3 and several cache. 
>
> Starting with hwloc v2.0, NUMA nodes are not in the main tree anymore. They are attached under objects as Memory Children on the side of normal children.


This PR fixes the hwloc topology detection in SSIDS to again correctly detect cores associated with NUMA nodes.

For more details please see the API change announcement here:
https://www.open-mpi.org/projects/hwloc/doc/v2.3.0/a00360.php
