### PR TITLE
Add full topology option to SSIDS C interface

### DIFF
--- a/docs/C/ssids.rst
+++ b/docs/C/ssids.rst
@@ -136,6 +136,52 @@ Basic Subroutines
    Provided for backwards comptability, users are encourage to use 64-bit ptr
    in new code.
 
+.. c:function:: void spral_ssids_analyse_topology(bool check, int n, int *order, const int64_t *ptr, const int *row, const double *val, void **akeep, const struct spral_ssids_options *options, struct spral_ssids_inform *inform, int nregions, const struct spral_numa_region *regions)
+
+   Perform the analyse (symbolic) phase of the factorization for a matrix
+   supplied in :doc:`CSC format<csc_format>` and specify the machine topology.
+   The resulting symbolic factors stored in :c:type:`akeep` should be passed
+   unaltered in the following call to :c:func:`spral_ssids_factor()`.
+
+   :param check: if true, matrix data is checked. Out-of-range entries
+      are dropped and duplicate entries are summed.
+   :param n: number of columns in :math:`A`.
+   :param order: may be `NULL`; otherwise must be an array of size `n`
+      used on entry a user-supplied ordering
+      (:c:type:`options.ordering=0 <spral_ssids_options.ordering>`).
+      On return, the actual ordering used.
+   :param ptr[n+1]: column pointers for :math:`A`
+      (see :doc:`CSC format<csc_format>`).
+   :param row[ptr[n]]: row indices for :math:`A`
+      (see :doc:`CSC format<csc_format>`).
+   :param val: may be `NULL`; otherwise must be an array of size `ptr[n]`
+      containing non-zero values for :math:`A`
+      (see :doc:`CSC format<csc_format>`).
+      Only used if a matching-based ordering is requested.
+   :param akeep: returns symbolic factorization, to be passed unchanged to
+      subsequent routines.
+   :param options: specifies algorithm options to be used
+      (see :c:type:`spral_ssids_options`).
+   :param inform: returns information about the execution of the routine
+      (see :c:type:`spral_ssids_inform`).
+   :param nregions: specifies the number of independent NUMA regions in
+      the machine topology.
+   :param regions: specifies the machine topology to be exploited.
+      Region `i` will use `regions[i].nproc` threads and is associated
+      with `regions[i].ngpu` GPUs in the integer array pointed to by
+      `topology[i].gpus`, which may be a NULL pointer. See the
+      :ref:`method section <ssids_method>` for details of how work is
+      divided.
+
+   .. note::
+
+      If a user-supplied ordering is used, it may be altered by this routine,
+      with the altered version returned in `order[]`. This version will be
+      equivalent to the original ordering, except that some supernodes may have
+      been amalgamated, a topographic ordering may have been applied to the
+      assembly tree and the order of columns within a supernode may have been
+      adjusted to improve cache locality.
+
 .. c:function:: void spral_ssids_analyse_coord(int n, int *order, int64_t ne, const int *row, const int *col, const double *val, void **akeep, const struct spral_ssids_options *options, struct spral_ssids_inform *inform)
 
    As :c:func:`spral_ssids_analyse()`, but for coordinate data. The variant
@@ -718,6 +764,23 @@ Derived types
    |             | the environment variable OMP_PROC_BIND=true (this may       |
    |             | affect performance on NUMA systems).                        |
    +-------------+-------------------------------------------------------------+
+
+
+.. c:type:: struct spral_numa_region
+
+   Used to specify information about an independent NUMA region to be exploited.
+
+   .. c:member:: int nproc
+
+      Number of threads in the NUMA region.
+
+   .. c:member:: int ngpu
+
+      Number of GPUs in the NUMA region.
+
+   .. c:member:: int* gpus
+
+      Pointer to an array of the GPUs in the NUMA region.
 
 .. _ssids_example:
 

--- a/docs/C/ssids.rst
+++ b/docs/C/ssids.rst
@@ -138,49 +138,16 @@ Basic Subroutines
 
 .. c:function:: void spral_ssids_analyse_topology(bool check, int n, int *order, const int64_t *ptr, const int *row, const double *val, void **akeep, const struct spral_ssids_options *options, struct spral_ssids_inform *inform, int nregions, const struct spral_numa_region *regions)
 
-   Perform the analyse (symbolic) phase of the factorization for a matrix
-   supplied in :doc:`CSC format<csc_format>` and specify the machine topology.
-   The resulting symbolic factors stored in :c:type:`akeep` should be passed
-   unaltered in the following call to :c:func:`spral_ssids_factor()`.
+   As :c:func:`spral_ssids_analyse()` with the following additional arguments.
 
-   :param check: if true, matrix data is checked. Out-of-range entries
-      are dropped and duplicate entries are summed.
-   :param n: number of columns in :math:`A`.
-   :param order: may be `NULL`; otherwise must be an array of size `n`
-      used on entry a user-supplied ordering
-      (:c:type:`options.ordering=0 <spral_ssids_options.ordering>`).
-      On return, the actual ordering used.
-   :param ptr[n+1]: column pointers for :math:`A`
-      (see :doc:`CSC format<csc_format>`).
-   :param row[ptr[n]]: row indices for :math:`A`
-      (see :doc:`CSC format<csc_format>`).
-   :param val: may be `NULL`; otherwise must be an array of size `ptr[n]`
-      containing non-zero values for :math:`A`
-      (see :doc:`CSC format<csc_format>`).
-      Only used if a matching-based ordering is requested.
-   :param akeep: returns symbolic factorization, to be passed unchanged to
-      subsequent routines.
-   :param options: specifies algorithm options to be used
-      (see :c:type:`spral_ssids_options`).
-   :param inform: returns information about the execution of the routine
-      (see :c:type:`spral_ssids_inform`).
    :param nregions: specifies the number of independent NUMA regions in
       the machine topology.
    :param regions: specifies the machine topology to be exploited.
       Region `i` will use `regions[i].nproc` threads and is associated
       with `regions[i].ngpu` GPUs in the integer array pointed to by
-      `topology[i].gpus`, which may be a NULL pointer. See the
-      :ref:`method section <ssids_method>` for details of how work is
+      `regions[i].gpus`, which may be a NULL pointer if `regions[i].ngpu = 0`.
+      See the :ref:`method section <ssids_method>` for details of how work is
       divided.
-
-   .. note::
-
-      If a user-supplied ordering is used, it may be altered by this routine,
-      with the altered version returned in `order[]`. This version will be
-      equivalent to the original ordering, except that some supernodes may have
-      been amalgamated, a topographic ordering may have been applied to the
-      assembly tree and the order of columns within a supernode may have been
-      adjusted to improve cache locality.
 
 .. c:function:: void spral_ssids_analyse_coord(int n, int *order, int64_t ne, const int *row, const int *col, const double *val, void **akeep, const struct spral_ssids_options *options, struct spral_ssids_inform *inform)
 

--- a/examples/C/meson.build
+++ b/examples/C/meson.build
@@ -5,4 +5,5 @@ subdir('ssmfe')
 spral_c_examples += [['lsmrs_c', files('lsmr.c')],
                      ['randoms_c', files('random.c')],
                      ['random_matrixs_c', files('random_matrix.c')],
-                     ['ssidss_c', files('ssids.c')]]
+                     ['ssidss_c', files('ssids.c')],
+                     ['ssids_topologys_c', files('ssids_topology.c')]]

--- a/examples/C/ssids_topology.c
+++ b/examples/C/ssids_topology.c
@@ -30,20 +30,15 @@ int main(void) {
    /* The right-hand side with solution (1.0, 2.0, 3.0, 4.0, 5.0) */
    double x[] = { 4.0, 17.0, 19.0, 2.0, 12.0 };
 
-   /* Fake topology:
-    * NUMA_REGION
-    *  CPU #1
-    * NUMA_REGION
-    *  CPU #2
-    *  GPU #1 */
+   /* Fake topology */
    int nregions = 2;
    struct spral_numa_region regions[nregions];
    regions[0].nproc = 1;
    regions[0].ngpu = 0;
    regions[0].gpus = NULL;
-   int gpus[] = {0,1};
    regions[1].nproc = 1;
    regions[1].ngpu = 2;
+   int gpus[] = {0,1};
    regions[1].gpus = (int *) &gpus;
 
    /* Perform analyse and factorise with data checking */

--- a/examples/C/ssids_topology.c
+++ b/examples/C/ssids_topology.c
@@ -31,7 +31,7 @@ int main(void) {
    double x[] = { 4.0, 17.0, 19.0, 2.0, 12.0 };
 
    /* Fake topology */
-   int nregions = 2;
+   #define nregions 2
    struct spral_numa_region regions[nregions];
    regions[0].nproc = 1;
    regions[0].ngpu = 0;

--- a/examples/C/ssids_topology.c
+++ b/examples/C/ssids_topology.c
@@ -39,7 +39,7 @@ int main(void) {
    regions[1].nproc = 1;
    regions[1].ngpu = 2;
    int gpus[] = {0,1};
-   regions[1].gpus = (int *) &gpus;
+   regions[1].gpus = gpus;
 
    /* Perform analyse and factorise with data checking */
    bool check = true;

--- a/examples/C/ssids_topology.c
+++ b/examples/C/ssids_topology.c
@@ -1,0 +1,85 @@
+/* examples/C/ssids_topology.c - Example code for SPRAL_SSIDS package */
+#include "spral.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+   /* Derived types */
+   void *akeep, *fkeep;
+   struct spral_ssids_options options;
+   struct spral_ssids_inform inform;
+
+   /* Initialize derived types */
+   akeep = NULL; fkeep = NULL; /* Important that these are NULL to start with */
+   spral_ssids_default_options(&options);
+   options.array_base = 1; /* Need to set to 1 if using Fortran 1-based indexing */
+
+   /* Data for matrix:
+    * ( 2  1         )
+    * ( 1  4  1    1 )
+    * (    1  3  2   )
+    * (       2 -1   )
+    * (    1       2 ) */
+   bool posdef = false;
+   int n = 5;
+   int64_t ptr[]   = { 1,        3,             6,         8,   9,  10 };
+   int row[]    = { 1,   2,   2,   3,   5,   3,   4,    4,   5   };
+   double val[] = { 2.0, 1.0, 4.0, 1.0, 1.0, 3.0, 2.0, -1.0, 2.0 };
+
+   /* The right-hand side with solution (1.0, 2.0, 3.0, 4.0, 5.0) */
+   double x[] = { 4.0, 17.0, 19.0, 2.0, 12.0 };
+
+   /* Fake topology:
+    * NUMA_REGION
+    *  CPU #1
+    * NUMA_REGION
+    *  CPU #2
+    *  GPU #1 */
+   int nregions = 2;
+   struct spral_numa_region regions[nregions];
+   regions[0].nproc = 1;
+   regions[0].ngpu = 0;
+   regions[0].gpus = NULL;
+   int gpus[] = {0};
+   regions[1].nproc = 1;
+   regions[1].ngpu = 1;
+   regions[1].gpus = gpus;
+
+   /* Perform analyse and factorise with data checking */
+   bool check = true;
+   spral_ssids_analyse_topology(check, n, NULL, ptr, row, NULL, &akeep, &options,
+         &inform, nregions, regions);
+   if(inform.flag<0) {
+      spral_ssids_free(&akeep, &fkeep);
+      exit(1);
+   }
+   spral_ssids_factor(posdef, NULL, NULL, val, NULL, akeep, &fkeep, &options,
+         &inform);
+   if(inform.flag<0) {
+      spral_ssids_free(&akeep, &fkeep);
+      exit(1);
+   }
+
+   /* Solve */
+   spral_ssids_solve1(0, x, akeep, fkeep, &options, &inform);
+   if(inform.flag<0) {
+      spral_ssids_free(&akeep, &fkeep);
+      exit(1);
+   }
+   printf("The computed solution is:\n");
+   for(int i=0; i<n; i++) printf(" %18.10e", x[i]);
+   printf("\n");
+
+   /* Determine and print the pivot order */
+   int piv_order[5];
+   spral_ssids_enquire_indef(akeep, fkeep, &options, &inform, piv_order, NULL);
+   printf("Pivot order:");
+   for(int i=0; i<n; i++) printf(" %5d", piv_order[i]);
+   printf("\n");
+
+   int cuda_error = spral_ssids_free(&akeep, &fkeep);
+   if(cuda_error!=0) exit(1);
+
+   return 0;
+}

--- a/examples/C/ssids_topology.c
+++ b/examples/C/ssids_topology.c
@@ -41,10 +41,10 @@ int main(void) {
    regions[0].nproc = 1;
    regions[0].ngpu = 0;
    regions[0].gpus = NULL;
-   int gpus[] = {0};
+   int gpus[] = {0,1};
    regions[1].nproc = 1;
-   regions[1].ngpu = 1;
-   regions[1].gpus = gpus;
+   regions[1].ngpu = 2;
+   regions[1].gpus = (int *) &gpus;
 
    /* Perform analyse and factorise with data checking */
    bool check = true;

--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -67,6 +67,11 @@ void spral_ssids_analyse(bool check, int n, int *order, const int64_t *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform);
+void spral_ssids_analyse_topology(bool check, int n, int *order, const int64_t *ptr,
+      const int *row, const double *val, void **akeep,
+      const struct spral_ssids_options *options,
+      struct spral_ssids_inform *inform,
+      int nproc, int ngpu, const int *gpus);
 void spral_ssids_analyse_ptr32(bool check, int n, int *order, const int *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,

--- a/include/spral_ssids.h
+++ b/include/spral_ssids.h
@@ -56,6 +56,12 @@ struct spral_ssids_inform {
    char unused[76]; // Allow for future expansion
 };
 
+struct spral_numa_region {
+   int nproc;
+   int ngpu;
+   int *gpus;
+};
+
 /************************************
  * Basic subroutines
  ************************************/
@@ -71,7 +77,7 @@ void spral_ssids_analyse_topology(bool check, int n, int *order, const int64_t *
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,
       struct spral_ssids_inform *inform,
-      int nproc, int ngpu, const int *gpus);
+      int nregions, const struct spral_numa_region *regions);
 void spral_ssids_analyse_ptr32(bool check, int n, int *order, const int *ptr,
       const int *row, const double *val, void **akeep,
       const struct spral_ssids_options *options,


### PR DESCRIPTION
This PR adds a new C interface function `ssids_analyse_topology` that allows the user to specify a machine topology in the same way the current Fortran `ssids_analyse` subroutine allows. We add a new interface function rather than modifying the existing `ssids_analyse` C interface function for backwards compatibility.

The topology can be specified in C as follows (see `examples/C/ssids_topology.c` for a full example):
```C
   /* Fake topology */
   #define nregions 2
   struct spral_numa_region regions[nregions];
   regions[0].nproc = 1;
   regions[0].ngpu = 0;
   regions[0].gpus = NULL;
   regions[1].nproc = 1;
   regions[1].ngpu = 2;
   int gpus[] = {0,1};
   regions[1].gpus = gpus;

   /* Perform analyse and factorise with data checking */
   bool check = true;
   spral_ssids_analyse_topology(check, n, NULL, ptr, row, NULL, &akeep, &options,
         &inform, nregions, regions);
```

@LiuZhexuan please test and let us know if you have any comments or feedback on this PR.