### PR TITLE
[CI] Drop ifort CI tests

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -17,16 +17,16 @@ jobs:
         metis: [32, 64]
         include:
           - compiler: gcc
-          - os: ubuntu-latest
-            compiler: intel
-            compiler_version: '2023.2'
-            metis: 32
-            allow_failure: true
-          - os: ubuntu-latest
-            compiler: intel
-            compiler_version: '2023.2'
-            metis: 64
-            allow_failure: true
+          # - os: ubuntu-latest
+          #   compiler: intel
+          #   compiler_version: '2023.2'
+          #   metis: 32
+          #   allow_failure: true
+          # - os: ubuntu-latest
+          #   compiler: intel
+          #   compiler_version: '2023.2'
+          #   metis: 64
+          #   allow_failure: true
           - os: macos-latest
             compiler: gcc
             compiler_version: '13'


### PR DESCRIPTION
Drop the Intel `ifort` tests for now as `ifort` is no longer shipped by Intel. Waiting for `ifx` to become mature enough and not throw `internal compiler errors` (it beggars belief Intel could have released it in such a broken state).