### PR TITLE
Add C function to return SPRAL version

### DIFF
--- a/include/spral.h
+++ b/include/spral.h
@@ -1,6 +1,10 @@
 #ifndef SPRAL_H
 #define SPRAL_H
 
+#define SPRAL_VERSION_YEAR    2025
+#define SPRAL_VERSION_MONTH   03
+#define SPRAL_VERSION_DAY     06
+
 #include "spral_lsmr.h"
 #include "spral_matrix_util.h"
 #include "spral_random.h"

--- a/include/spral.h
+++ b/include/spral.h
@@ -1,9 +1,7 @@
 #ifndef SPRAL_H
 #define SPRAL_H
 
-#define SPRAL_VERSION_YEAR    2025
-#define SPRAL_VERSION_MONTH   03
-#define SPRAL_VERSION_DAY     06
+#define SPRAL_VERSION "2025.03.06"
 
 #include "spral_lsmr.h"
 #include "spral_matrix_util.h"

--- a/include/spral.h
+++ b/include/spral.h
@@ -12,4 +12,6 @@
 #include "spral_ssids.h"
 #include "spral_ssmfe.h"
 
+void get_spral_version(char version[11]);
+
 #endif // SPRAL_H

--- a/meson.build
+++ b/meson.build
@@ -152,6 +152,7 @@ endif
 
 binspral_src = []
 libspral_src = []
+libspral_c_src = []
 libspral_cpp_src = []
 libspral_nvcc_src = []
 
@@ -179,7 +180,7 @@ subdir('tests')
 
 # Library
 libspral = library('spral',
-                   sources : libspral_src + libspral_cpp_src + libspral_nvcc_src,
+                   sources : libspral_src + libspral_c_src + libspral_cpp_src + libspral_nvcc_src,
                    dependencies : libspral_deps,
                    link_language : 'fortran',
                    link_args : lstdcpp,

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,8 @@ libspral_src += files('blas_iface.f90',
                       'scaling.f90',
                       'timer.f90')
 
+libspral_c_src += files('version.c')
+
 libspral_cpp_src += files('compat.cxx',
                           'omp.cxx')
 

--- a/src/version.c
+++ b/src/version.c
@@ -1,16 +1,6 @@
 #include "spral.h"
 #include <string.h>
-#include <stdio.h>
 
 void get_spral_version(char version[11]) {
     strcpy(version, SPRAL_VERSION);
-}
-
-int main(void) {
-
-    char version[11];
-    get_spral_version(version);
-    printf("SPRAL version: %s\n", version);
-
-    return 0;
 }

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,17 @@
+#include "spral.h"
+#include <stdio.h>
+
+void get_spral_version(int *year, int *month, int *day) {
+    *year = SPRAL_VERSION_YEAR;
+    *month = SPRAL_VERSION_MONTH;
+    *day = SPRAL_VERSION_DAY;
+}
+
+int main(void) {
+
+    int year, month, day;
+    get_spral_version(&year, &month, &day);
+    printf("SPRAL version: %4d.%02d.%02d\n", year, month, day);
+
+    return 0;
+}

--- a/src/version.c
+++ b/src/version.c
@@ -1,17 +1,16 @@
 #include "spral.h"
+#include <string.h>
 #include <stdio.h>
 
-void get_spral_version(int *year, int *month, int *day) {
-    *year = SPRAL_VERSION_YEAR;
-    *month = SPRAL_VERSION_MONTH;
-    *day = SPRAL_VERSION_DAY;
+void get_spral_version(char version[11]) {
+    strcpy(version, SPRAL_VERSION);
 }
 
 int main(void) {
 
-    int year, month, day;
-    get_spral_version(&year, &month, &day);
-    printf("SPRAL version: %4d.%02d.%02d\n", year, month, day);
+    char version[11];
+    get_spral_version(version);
+    printf("SPRAL version: %s\n", version);
 
     return 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,3 +6,5 @@ spral_tests += [['lsmr', 'lsmrt', files('lsmr.f90')],
                 ['random', 'random_matrixt', files('random_matrix.f90')],
                 ['rb', 'rutherford_boeingt', files('rutherford_boeing.f90')],
                 ['scaling', 'scalingt', files('scaling.f90')]]
+
+spral_c_tests += [['spral', 'versiont_c', files('version.c')]]

--- a/tests/version.c
+++ b/tests/version.c
@@ -1,0 +1,11 @@
+#include "spral.h"
+#include <stdio.h>
+
+int main(void) {
+
+    char version[11];
+    get_spral_version(version);
+    printf("SPRAL version: %s\n", version);
+
+    return 0;
+}


### PR DESCRIPTION
Resolves #251 

@amontoison is it better to hardcode the version in `spral.h` or should this be populated with macros from `meson.build`? Also rather annoying that I have to use zero based padding to get the full version number correctly. 