### PR TITLE
Only enable hwloc IO device filters when built with CUDA

### DIFF
--- a/src/hw_topology/hwloc_wrapper.hxx
+++ b/src/hw_topology/hwloc_wrapper.hxx
@@ -37,6 +37,7 @@ public:
    /** \brief Constructor */
    HwlocTopology() {
       hwloc_topology_init(&topology_);
+#ifdef HAVE_NVCC
 #if HWLOC_API_VERSION >= 0x20000
       hwloc_topology_set_type_filter(topology_, HWLOC_OBJ_OS_DEVICE,
             HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
@@ -45,6 +46,7 @@ public:
 #else /* HWLOC_API_VERSION */
       hwloc_topology_set_flags(topology_, HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
 #endif /* HWLOC_API_VERSION */
+#endif /* HAVE_NVCC */
       hwloc_topology_load(topology_);
    }
    /** \brief Destructor */


### PR DESCRIPTION
While looking at the `ssids` fork in GALAHAD, I noticed a divergence in the `HwlocTopology` wrapper that is worth backporting here.

In the `HwlocTopology` constructor we unconditionally set the hwloc type filters (or the `HWLOC_TOPOLOGY_FLAG_IO_DEVICES` flag on older hwloc) to force discovery of PCI/OS devices:

```cpp
HwlocTopology() {
   hwloc_topology_init(&topology_);
#if HWLOC_API_VERSION >= 0x20000
   hwloc_topology_set_type_filter(topology_, HWLOC_OBJ_OS_DEVICE,  HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
   hwloc_topology_set_type_filter(topology_, HWLOC_OBJ_PCI_DEVICE, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
#else
   hwloc_topology_set_flags(topology_, HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
#endif
   hwloc_topology_load(topology_);
}
```

Those IO devices are only ever consumed by `get_gpus()` to locate CUDA GPUs in the topology tree, and `get_gpus()` is itself guarded by `HAVE_NVCC`. So on CPU-only builds (the common case) this device discovery is pure wasted work at topology-load time.

This PR simply wraps that block in `#ifdef HAVE_NVCC`, matching what is done in the GALAHAD fork.

I also have a vague recollection that forcing this IO discovery could leak memory in some configurations.
I couldn't reproduce/confirm it from the code here (the topology is destroyed in the destructor), so treat that as a "to confirm" rather than a claim. Either way, skipping the work on CPU-only builds is the right thing to do.