### PR TITLE
Fix bugs with complex numbers in SSMFE

### DIFF
--- a/interfaces/C/ssmfe.f90
+++ b/interfaces/C/ssmfe.f90
@@ -231,19 +231,19 @@ subroutine spral_ssmfe_generalized_double_complex(crci, left, mep, lambda, n, &
   use spral_ssmfe_ciface
   implicit none
 
-  type(spral_ssmfe_rcid), intent(inout) :: crci
+  type(spral_ssmfe_rciz), intent(inout) :: crci
   integer(C_INT), value :: left
   integer(C_INT), value :: mep
   real(C_DOUBLE), dimension(mep), intent(inout) :: lambda
   integer(C_INT), value :: n
   integer(C_INT), value :: ldx
-  real(C_DOUBLE), dimension(ldx, mep), intent(inout) :: x
+  complex(C_DOUBLE_COMPLEX), dimension(ldx, mep), intent(inout) :: x
   type(C_PTR), intent(inout) :: ckeep
   type(spral_ssmfe_options), intent(in) :: coptions
   type(spral_ssmfe_inform), intent(inout) :: cinform
 
   logical :: cindexed
-  type(ssmfe_ciface_keepd), pointer :: fcikeep
+  type(ssmfe_ciface_keepz), pointer :: fcikeep
   type(ssmfe_options) :: foptions
 
   ! Copy options in first to find out whether we use Fortran or C indexing

--- a/tests/ssmfe/ssmfe_ciface.c
+++ b/tests/ssmfe/ssmfe_ciface.c
@@ -1140,7 +1140,7 @@ int test_ssmfe_d(int problem) {
             &keep, &options, &inform );
          break;
       case 1:
-         spral_ssmfe_standard_double( &rci, nep, 2*nep, lambda, n, &(*X)[0][0], n,
+         spral_ssmfe_generalized_double( &rci, nep, 2*nep, lambda, n, &(*X)[0][0], n,
             &keep, &options, &inform );
          break;
       case 2:
@@ -1267,7 +1267,7 @@ int test_ssmfe_z(int problem) {
             &keep, &options, &inform );
          break;
       case 1:
-         spral_ssmfe_standard_double_complex(
+         spral_ssmfe_generalized_double_complex(
             &rci, nep, 2*nep, lambda, n, &(*X)[0][0], n,
             &keep, &options, &inform );
          break;


### PR DESCRIPTION
`spral_ssmfe_generalized_double_complex` was a partial copy of the real version: `crci` was `spral_ssmfe_rcid` (`real`) instead of `rciz`, `x` was `real(C_DOUBLE)` instead of `complex(C_DOUBLE_COMPLEX)`, and `fcikeep` was `ssmfe_ciface_keepd` instead of `keepz`.

Why it was never caught: no test called this entry point. In `tests/ssmfe/ssmfe_ciface.c` the 'case 1' (generalized) of `test_ssmfe_d` and `test_ssmfe_z` was itself a copy-paste of 'case 0', calling the *standard* driver instead of the *generalized* one.
So `spral_ssmfe_generalized_double` and `spral_ssmfe_generalized_double_complex` had zero direct coverage.
